### PR TITLE
Setup json-schema usage

### DIFF
--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path("", view=views.index, name="index"),
+]

--- a/backend/api/validators.py
+++ b/backend/api/validators.py
@@ -1,0 +1,24 @@
+import json
+from typing import Any
+
+import jsonschema
+from django.conf import settings
+
+
+class InvalidData(Exception):
+    pass
+
+
+class SchemaValidator:
+    __schema_dir = settings.BASE_DIR / "schemas"
+
+    def __init__(self) -> None:
+        self._schema = None
+        with open(self.__schema_dir / "question.json") as file:
+            self._schema = json.load(file)
+
+    def validate(self, data: Any):
+        try:
+            jsonschema.validate(data, self._schema)
+        except jsonschema.exceptions.ValidationError as err:
+            raise InvalidData(err.message)

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -6,7 +6,7 @@ from .validators import SchemaValidator
 import json
 
 
-schema = SchemaValidator()
+validator = SchemaValidator()
 
 
 @csrf_exempt
@@ -17,7 +17,7 @@ def index(request):
         json_data = json.loads(data.decode("utf8"))
 
         # Validate data
-        schema.validate(json_data)
+        validator.validate(json_data)
 
         # Do something else
         print("Valid question :", json_data)

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -1,3 +1,25 @@
-from django.shortcuts import render
+# from django.shortcuts import render
+from django.http import HttpResponse
 
-# Create your views here.
+from django.views.decorators.csrf import csrf_exempt
+from .validators import SchemaValidator
+import json
+
+
+schema = SchemaValidator()
+
+
+@csrf_exempt
+def index(request):
+    if request.method == "POST":
+        # Get data from request body and parse it as json
+        data = request.body
+        json_data = json.loads(data.decode("utf8"))
+
+        # Validate data
+        schema.validate(json_data)
+
+        # Do something else
+        print("Valid question :", json_data)
+
+    return HttpResponse("Done !")

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -14,8 +14,9 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 
 urlpatterns = [
+    path("api/", include("backend.api.urls")),
     path("admin/", admin.site.urls),
 ]

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,16 +1,17 @@
 {
-	"extends": "@vue/tsconfig/tsconfig.web.json",
-	"include": ["env.d.ts", "src/**/*", "src/**/*.vue"],
-	"compilerOptions": {
-		"baseUrl": ".",
-		"paths": {
-			"@/*": ["./src/*"]
-		}
-	},
+    "extends": "@vue/tsconfig/tsconfig.web.json",
+    "include": ["env.d.ts", "src/**/*", "src/**/*.vue"],
+    "compilerOptions": {
+        "baseUrl": ".",
+        "paths": {
+            "@/*": ["./src/*"],
+            "@schemas/*": ["../schemas/*"]
+        }
+    },
 
-	"references": [
-		{
-			"path": "./tsconfig.config.json"
-		}
-	]
+    "references": [
+        {
+            "path": "./tsconfig.config.json"
+        }
+    ]
 }

--- a/schemas/interface.ts
+++ b/schemas/interface.ts
@@ -1,0 +1,18 @@
+
+/**
+ * Question objects used to create a quiz. A Quiz is a set of questions
+ * 
+ * @version 0.1.0
+ */
+export interface Question {
+    /**
+     * Id of the question
+     * 
+     * @pattern [a-z0-9]{12}
+     */
+    id: string;
+    /**
+     * The actual question as a human readable string.
+     */
+    question: string;
+}

--- a/schemas/question.json
+++ b/schemas/question.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
+    "description": "Question objects used to create a quiz. A Quiz is a set of questions",
+    "properties": {
+        "id": {
+            "description": "Id of the question",
+            "pattern": "[a-z0-9]{12}",
+            "type": "string"
+        },
+        "question": {
+            "description": "The actual question as a human readable string.",
+            "type": "string"
+        }
+    },
+    "type": "object"
+}
+


### PR DESCRIPTION
This PR does 2 things:
- create a `schemas` directory to hold everything relatives to json schemas. It is like a package shared by frontend and backend
- Implement a basic validator that use `jsonschema` to validate data before saving them in the database. We might want to use `pymongo` instead of `djongo` at some point.

What's next ?
-------------
- frontend can use the interfaces in the schemas dir. I believe we can use the schemas to write clean code + have consistency when making api requests. i'm thinking of something like
```typescript
// frontend/src/some-helper.ts

import { Question } from "@schemas/interface";

// Do some work using the Question interface
```

What do you think ?
