### PR TITLE
Implements `QuizPreview` and `QuestionWrapper` factory

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "[vue]": {
         "editor.formatOnSave": true,
-        "editor.defaultFormatter": "Vue.volar"
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
 }

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import Navbar from '@/components/Navbar.vue';
 import Footer from '@/components/Footer.vue';
-
 </script>
 
 <template>

--- a/frontend/src/components/Footer.vue
+++ b/frontend/src/components/Footer.vue
@@ -4,7 +4,10 @@
     <div id="footer">
         <div class="container">
             <div class="icons">
-                <a class="icon" href="https://fr-fr.facebook.com/BeninExcellence/">
+                <a
+                    class="icon"
+                    href="https://fr-fr.facebook.com/BeninExcellence/"
+                >
                     <font-awesome-icon icon="fa-brands fa-facebook-f" />
                 </a>
                 <a class="icon" href="https://twitter.com/excellencebenin">
@@ -13,15 +16,23 @@
                 <a class="icon" href="#i">
                     <font-awesome-icon icon="fa-brands fa-instagram" />
                 </a>
-                <a class="icon" target="_blank" rel="noreferrer"
-                    href="https://www.linkedin.com/company/benin-excellence/">
+                <a
+                    class="icon"
+                    target="_blank"
+                    rel="noreferrer"
+                    href="https://www.linkedin.com/company/benin-excellence/"
+                >
                     <font-awesome-icon icon="fa-brands fa-linkedin-in" />
                 </a>
             </div>
             <ul class="copyright">
                 <li>&copy; Fondation Vallet</li>
                 <li>
-                    <a target="_blank" rel="noreferrer" href="https://www.fondationvallet.org/eeia/">
+                    <a
+                        target="_blank"
+                        rel="noreferrer"
+                        href="https://www.fondationvallet.org/eeia/"
+                    >
                         École d'Été en Intelligence Artificielle (EEIA)
                     </a>
                 </li>
@@ -45,7 +56,7 @@
     font-size: 2.7em;
     text-align: center;
     padding-top: 1em;
-    padding-bottom: .5em;
+    padding-bottom: 0.5em;
 }
 
 .icon {

--- a/frontend/src/components/Navbar.vue
+++ b/frontend/src/components/Navbar.vue
@@ -5,18 +5,17 @@
         <div class="navbar">
             <ul class="links">
                 <li class="menu-item">
-                    <router-link to="/" title="Home">
-                        Home
-                    </router-link>
+                    <router-link to="/" title="Home"> Home </router-link>
                 </li>
                 <li class="menu-item">
-                    <router-link to="/news" title="News">
-                        News
-                    </router-link>
+                    <router-link to="/news" title="News"> News </router-link>
                 </li>
                 <li id="logo">
                     <router-link to="/" title="Logo">
-                        <img src="../assets/logo-no-background.svg" alt="Quizoot Logo" />
+                        <img
+                            src="../assets/logo-no-background.svg"
+                            alt="Quizoot Logo"
+                        />
                     </router-link>
                 </li>
                 <li class="menu-item">
@@ -25,9 +24,7 @@
                     </router-link>
                 </li>
                 <li class="menu-item">
-                    <router-link to="/about" title="About">
-                        About
-                    </router-link>
+                    <router-link to="/about" title="About"> About </router-link>
                 </li>
             </ul>
         </div>
@@ -75,7 +72,6 @@
 .links li.menu-item {
     flex: 1;
     height: 60%;
-
 }
 
 .links li.menu-item a {
@@ -107,7 +103,7 @@
     }
 
     .links li.menu-item a {
-        font-size: .8em;
+        font-size: 0.8em;
     }
 }
 

--- a/frontend/src/components/QuizCard.vue
+++ b/frontend/src/components/QuizCard.vue
@@ -16,7 +16,12 @@ const bgColor = computed(() => (quiz.status ? '#008000' : '#dfe2ec'));
     <div class="quiz-preview-container">
         <div class="quiz-status-container">
             <div class="quiz-status" v-on:click="quiz.status = !quiz.status">
-                <font-awesome-icon icon="fa-solid fa-check" color="#ffffff" size="lg" v-if="quiz.status"/>
+                <font-awesome-icon
+                    icon="fa-solid fa-check"
+                    color="#ffffff"
+                    size="lg"
+                    v-if="quiz.status"
+                />
             </div>
         </div>
         <div class="quiz-details">
@@ -29,7 +34,7 @@ const bgColor = computed(() => (quiz.status ? '#008000' : '#dfe2ec'));
         </div>
         <div class="quiz-details-expand-icon-container">
             <div class="quiz-details-expand-icon">
-                <font-awesome-icon icon="fa-solid fa-chevron-right" size="lg"/>
+                <font-awesome-icon icon="fa-solid fa-chevron-right" size="lg" />
             </div>
         </div>
     </div>
@@ -107,7 +112,7 @@ const bgColor = computed(() => (quiz.status ? '#008000' : '#dfe2ec'));
     }
 }
 
-.quiz-preview-container .quiz-details>* {
+.quiz-preview-container .quiz-details > * {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -115,7 +120,7 @@ const bgColor = computed(() => (quiz.status ? '#008000' : '#dfe2ec'));
     height: 35%;
 }
 
-.quiz-preview-container .quiz-details>*>* {
+.quiz-preview-container .quiz-details > * > * {
     width: 100%;
     height: fit-content;
     margin: 0;

--- a/frontend/src/components/QuizPreview.vue
+++ b/frontend/src/components/QuizPreview.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import type { Quizoot } from "@schemas/interface";
+import { defineProps } from "vue";
+
+interface QuizPreviewProps {
+    questionsCount: number;
+    description: string;
+    authors?: Quizoot.Author[];
+    onStart: () => void;
+}
+
+const props = defineProps<QuizPreviewProps>();
+
+// Get the first author (for now)
+const author = props.authors?.[0];
+</script>
+
+<template>
+    <div class="quiz-subtitle">
+        Interactive Quiz <span>&#8226;</span> <span class="question-count">{{ props.questionsCount }}</span>
+        Questions
+        <p v-if="author">By {{ author.name }} {{ author.surname }}</p>
+    </div>
+    <div class="quiz-content">
+        <p>{{ props.description }}</p>
+    </div>
+    <div class="btn-group">
+        <button @click="onStart">
+            Start the quiz <span>&#187;</span>
+        </button>
+    </div>
+
+</template>
+
+<style>
+.quiz-subtitle {
+    margin-top: 5px;
+}
+
+.quiz-content {
+    text-align: left;
+    font-size: 1.2em;
+}
+
+.question-count {
+    font-weight: 800;
+    color: var(--palette-well-read);
+}
+</style>

--- a/frontend/src/components/QuizPreview.vue
+++ b/frontend/src/components/QuizPreview.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import type { Quizoot } from "@schemas/interface";
-import { defineProps } from "vue";
+import type { Quizoot } from '@schemas/interface';
+import { defineProps, computed } from 'vue';
 
 interface QuizPreviewProps {
     questionsCount: number;
@@ -12,12 +12,13 @@ interface QuizPreviewProps {
 const props = defineProps<QuizPreviewProps>();
 
 // Get the first author (for now)
-const author = props.authors?.[0];
+const author = computed(() => props.authors?.[0]);
 </script>
 
 <template>
     <div class="quiz-subtitle">
-        Interactive Quiz <span>&#8226;</span> <span class="question-count">{{ props.questionsCount }}</span>
+        Interactive Quiz <span>&#8226;</span>
+        <span class="question-count">{{ props.questionsCount }}</span>
         Questions
         <p v-if="author">By {{ author.name }} {{ author.surname }}</p>
     </div>
@@ -25,11 +26,8 @@ const author = props.authors?.[0];
         <p>{{ props.description }}</p>
     </div>
     <div class="btn-group">
-        <button @click="onStart">
-            Start the quiz <span>&#187;</span>
-        </button>
+        <button @click="onStart">Start the quiz <span>&#187;</span></button>
     </div>
-
 </template>
 
 <style>

--- a/frontend/src/components/questions/ChoiceQuestion.vue
+++ b/frontend/src/components/questions/ChoiceQuestion.vue
@@ -2,6 +2,4 @@
     <div>Hello <code>ChoiceQuestion</code></div>
 </template>
 
-<style>
-
-</style>
+<style></style>

--- a/frontend/src/components/questions/ChoiceQuestion.vue
+++ b/frontend/src/components/questions/ChoiceQuestion.vue
@@ -1,0 +1,7 @@
+<template>
+    <div>Hello <code>ChoiceQuestion</code></div>
+</template>
+
+<style>
+
+</style>

--- a/frontend/src/components/questions/CodeQuestion.vue
+++ b/frontend/src/components/questions/CodeQuestion.vue
@@ -1,0 +1,7 @@
+<template>
+    <div>Hello <code>CodeQuestion</code></div>
+</template>
+
+<style>
+
+</style>

--- a/frontend/src/components/questions/CodeQuestion.vue
+++ b/frontend/src/components/questions/CodeQuestion.vue
@@ -2,6 +2,4 @@
     <div>Hello <code>CodeQuestion</code></div>
 </template>
 
-<style>
-
-</style>
+<style></style>

--- a/frontend/src/components/questions/QuestionWrapper.vue
+++ b/frontend/src/components/questions/QuestionWrapper.vue
@@ -34,26 +34,12 @@ function getQuestionComponent() {
 
 const componentId = computed(getQuestionComponent);
 </script>
+
 <template>
     <div class="progress-bar"></div>
     <div class="question">
         <component :is="componentId" />
     </div>
 </template>
-<style>
-.quiz-container {
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-start;
-    align-items: center;
-    width: 65%;
-    margin-left: 17.5%;
-    margin-right: 17.5%;
-    padding-bottom: 30px;
-    min-height: 60vh;
-}
 
-.quiz-title {
-    margin-bottom: 0;
-}
-</style>
+<style></style>

--- a/frontend/src/components/questions/QuestionWrapper.vue
+++ b/frontend/src/components/questions/QuestionWrapper.vue
@@ -19,26 +19,23 @@ const props = defineProps<QuestionWrapperProps>();
 // the questions component.
 function getQuestionComponent() {
     switch (props.question.kind) {
-        case "CHOICE_QUESTION":
+        case 'CHOICE_QUESTION':
             return ChoiceQuestion;
-        case "CODE_QUESTION":
+        case 'CODE_QUESTION':
             return CodeQuestion;
-        case "TEXT_QUESTION":
+        case 'TEXT_QUESTION':
             return TextQuestion;
-        case "UPLOAD_QUESTION":
+        case 'UPLOAD_QUESTION':
             return UploadQuestion;
         default:
-            throw Error("Unknown Question");
+            throw Error('Unknown Question');
     }
 }
 
 const componentId = computed(getQuestionComponent);
-
 </script>
 <template>
-    <div class="progress-bar">
-
-    </div>
+    <div class="progress-bar"></div>
     <div class="question">
         <component :is="componentId" />
     </div>

--- a/frontend/src/components/questions/QuestionWrapper.vue
+++ b/frontend/src/components/questions/QuestionWrapper.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import { computed, defineProps } from 'vue';
+
+import type { Quizoot } from '@schemas/interface';
+
+/** Import the different questions */
+import CodeQuestion from './CodeQuestion.vue';
+import ChoiceQuestion from './ChoiceQuestion.vue';
+import TextQuestion from './TextQuestion.vue';
+import UploadQuestion from './UploadQuestion.vue';
+
+interface QuestionWrapperProps {
+    question: Quizoot.Question;
+}
+
+const props = defineProps<QuestionWrapperProps>();
+
+// TODO: write a generic factory that automatically finds
+// the questions component.
+function getQuestionComponent() {
+    switch (props.question.kind) {
+        case "CHOICE_QUESTION":
+            return ChoiceQuestion;
+        case "CODE_QUESTION":
+            return CodeQuestion;
+        case "TEXT_QUESTION":
+            return TextQuestion;
+        case "UPLOAD_QUESTION":
+            return UploadQuestion;
+        default:
+            throw Error("Unknown Question");
+    }
+}
+
+const componentId = computed(getQuestionComponent);
+
+</script>
+<template>
+    <div class="progress-bar">
+
+    </div>
+    <div class="question">
+        <component :is="componentId" />
+    </div>
+</template>
+<style>
+.quiz-container {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: center;
+    width: 65%;
+    margin-left: 17.5%;
+    margin-right: 17.5%;
+    padding-bottom: 30px;
+    min-height: 60vh;
+}
+
+.quiz-title {
+    margin-bottom: 0;
+}
+</style>

--- a/frontend/src/components/questions/QuestionWrapper.vue
+++ b/frontend/src/components/questions/QuestionWrapper.vue
@@ -4,8 +4,8 @@ import { computed, defineProps } from 'vue';
 import type { Quizoot } from '@schemas/interface';
 
 /** Import the different questions */
-import CodeQuestion from './CodeQuestion.vue';
 import ChoiceQuestion from './ChoiceQuestion.vue';
+import CodeQuestion from './CodeQuestion.vue';
 import TextQuestion from './TextQuestion.vue';
 import UploadQuestion from './UploadQuestion.vue';
 
@@ -28,7 +28,7 @@ function getQuestionComponent() {
         case 'UPLOAD_QUESTION':
             return UploadQuestion;
         default:
-            throw Error('Unknown Question');
+            throw Error(`Unknown QuestionKind "${props.question.kind}"`);
     }
 }
 

--- a/frontend/src/components/questions/TextQuestion.vue
+++ b/frontend/src/components/questions/TextQuestion.vue
@@ -1,0 +1,7 @@
+<template>
+    <div>Hello <code>TextQuestion</code></div>
+</template>
+
+<style>
+
+</style>

--- a/frontend/src/components/questions/TextQuestion.vue
+++ b/frontend/src/components/questions/TextQuestion.vue
@@ -2,6 +2,4 @@
     <div>Hello <code>TextQuestion</code></div>
 </template>
 
-<style>
-
-</style>
+<style></style>

--- a/frontend/src/components/questions/UploadQuestion.vue
+++ b/frontend/src/components/questions/UploadQuestion.vue
@@ -2,6 +2,4 @@
     <div>Hello <code>UploadQuestion</code></div>
 </template>
 
-<style>
-
-</style>
+<style></style>

--- a/frontend/src/components/questions/UploadQuestion.vue
+++ b/frontend/src/components/questions/UploadQuestion.vue
@@ -1,0 +1,7 @@
+<template>
+    <div>Hello <code>UploadQuestion</code></div>
+</template>
+
+<style>
+
+</style>

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -25,3 +25,29 @@ body {
     background-color: var(--background-color);
     overflow: hidden;
 }
+
+.btn-group {
+    display: flex;
+    width: 100%;
+    justify-content: flex-end;
+    align-items: center;
+}
+
+.btn-group button {
+    background-color: var(--palette-mobster);
+    color: white;
+    font-weight: 600;
+    font-size: 1.1em;
+    padding-left: 10px;
+    padding-right: 10px;
+    width: auto;
+    min-height: 40px;
+    border-radius: 5px;
+    cursor: pointer;
+    border: none;
+}
+
+.btn-group button:hover {
+    transform: translate(2px, 2px);
+    opacity: 0.8;
+}

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import QuizCard from '@/components/QuizCard.vue';
-import { useRouter } from "vue-router";
+import { useRouter } from 'vue-router';
 
 const router = useRouter();
 function goToQuiz(quizId: number) {

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -1,17 +1,11 @@
-<script lang="ts">
-import { defineComponent } from 'vue';
+<script setup lang="ts">
 import QuizCard from '@/components/QuizCard.vue';
+import { useRouter } from "vue-router";
 
-export default defineComponent({
-    components: {
-        QuizCard,
-    },
-    methods: {
-        goToQuiz(quizId: number) {
-            this.$router.push({ path: `/quiz/${quizId}` });
-        }
-    },
-})
+const router = useRouter();
+function goToQuiz(quizId: number) {
+    router.push({ path: `/quiz/${quizId}` });
+}
 </script>
 
 <template>

--- a/frontend/src/views/Quiz.vue
+++ b/frontend/src/views/Quiz.vue
@@ -1,19 +1,18 @@
 <script setup lang="ts">
-import { defineProps, withDefaults, ref } from "vue";
-import type { Ref } from "vue";
-import QuizPreview from "@/components/QuizPreview.vue";
-import QuestionWrapper from "@/components/questions/QuestionWrapper.vue";
-import type { Quizoot } from "@schemas/interface";
-import quiz from "@/data/quiz-data-types.json";
+import { defineProps, withDefaults, ref } from 'vue';
+import type { Ref } from 'vue';
+import QuizPreview from '@/components/QuizPreview.vue';
+import QuestionWrapper from '@/components/questions/QuestionWrapper.vue';
+import type { Quizoot } from '@schemas/interface';
+import quiz from '@/data/quiz-data-types.json';
 
 interface QuizProps {
     data: Quizoot.Quiz;
 }
 
-const props = withDefaults(defineProps<QuizProps>(), {
-    data: () => (quiz as Quizoot.Quiz)
+withDefaults(defineProps<QuizProps>(), {
+    data: () => quiz as Quizoot.Quiz,
 });
-const { data } = props;
 
 const currentQuestion: Ref<number | null> = ref(null);
 function startQuiz() {
@@ -24,8 +23,13 @@ function startQuiz() {
 <template>
     <div class="quiz-container">
         <h1 class="quiz-title">{{ data.title }}</h1>
-        <QuizPreview v-if="currentQuestion == null" :questionsCount="data.questions.length"
-            :description="data.description" :authors="data.authors" :onStart=startQuiz />
+        <QuizPreview
+            v-if="currentQuestion == null"
+            :questionsCount="data.questions.length"
+            :description="data.description"
+            :authors="data.authors"
+            :onStart="startQuiz"
+        />
         <QuestionWrapper v-else :question="data.questions[currentQuestion]" />
     </div>
 </template>

--- a/frontend/src/views/Quiz.vue
+++ b/frontend/src/views/Quiz.vue
@@ -1,27 +1,33 @@
 <script setup lang="ts">
-</script> 
+import { defineProps, withDefaults, ref } from "vue";
+import type { Ref } from "vue";
+import QuizPreview from "@/components/QuizPreview.vue";
+import QuestionWrapper from "@/components/questions/QuestionWrapper.vue";
+import type { Quizoot } from "@schemas/interface";
+import quiz from "@/data/quiz-data-types.json";
+
+interface QuizProps {
+    data: Quizoot.Quiz;
+}
+
+const props = withDefaults(defineProps<QuizProps>(), {
+    data: () => (quiz as Quizoot.Quiz)
+});
+const { data } = props;
+
+const currentQuestion: Ref<number | null> = ref(null);
+function startQuiz() {
+    currentQuestion.value = 0;
+}
+</script>
 
 <template>
     <div class="quiz-container">
-        <h1 class="quiz-title">Basic Data Types in Python Quiz</h1>
-        <div class="quiz-subtitle">
-            Interactive Quiz <span>&#8226;</span> <span class="question-count">20</span> Questions
-            <p>By Author Name</p>
-        </div>
-        <div class="quiz-content">
-            <p>
-                Test your understanding of the basic data types that are built into Python, like numbers, strings,
-                and
-                Booleans.
-            </p>
-        </div>
-        <div class="btn-group">
-            <button>
-                Start the quiz <span>&#187;</span>
-            </button>
-        </div>
+        <h1 class="quiz-title">{{ data.title }}</h1>
+        <QuizPreview v-if="currentQuestion == null" :questionsCount="data.questions.length"
+            :description="data.description" :authors="data.authors" :onStart=startQuiz />
+        <QuestionWrapper v-else :question="data.questions[currentQuestion]" />
     </div>
-
 </template>
 
 <style>
@@ -39,45 +45,5 @@
 
 .quiz-title {
     margin-bottom: 0;
-}
-
-.quiz-subtitle {
-    margin-top: 5px;
-}
-
-.quiz-content {
-    text-align: left;
-    font-size: 1.2em;
-}
-
-.question-count {
-    font-weight: 800;
-    color: var(--palette-well-read);
-}
-
-.btn-group {
-    display: flex;
-    width: 100%;
-    justify-content: flex-end;
-    align-items: center;
-}
-
-.btn-group button {
-    background-color: var(--palette-mobster);
-    color: white;
-    font-weight: 600;
-    font-size: 1.1em;
-    padding-left: 10px;
-    padding-right: 10px;
-    width: auto;
-    min-height: 40px;
-    border-radius: 5px;
-    cursor: pointer;
-    border: none;
-}
-
-.btn-group button:hover {
-    transform: translate(2px, 2px);
-    opacity: 0.8;
 }
 </style>

--- a/schemas/interface.ts
+++ b/schemas/interface.ts
@@ -1,4 +1,4 @@
-declare namespace Quizoot {
+export declare namespace Quizoot {
     /**
      * Question object used to create a quiz. A Quiz is a set of questions.
      *
@@ -126,6 +126,12 @@ declare namespace Quizoot {
 
     interface TextQuestion {
         /**
+         * Placeholder to display in the html `textarea` or `input`
+         * 
+         * @examples ["Type your text here..."]
+         */
+        placeholder?: string;
+        /**
          * List of keywords that the answers should contain. It is up to the developer to implement if the answer should contain ALL or ANY of the keywords.
          * 
          * @examples ["bytes", "octets"]
@@ -217,7 +223,7 @@ declare namespace Quizoot {
         /**
          * All the questions the quiz is made of.
          */
-        questions: QuestionItem[]
+        questions: Question[]
         /**
          * List of optional authors or contributors of the quiz. See {@link Author}.
          */
@@ -249,11 +255,11 @@ declare namespace Quizoot {
         /**
          * The quiz author's first name.
          */
-        firstName: string;
+        name: string;
         /**
          * The quiz author's last name. Is optional.
          */
-        lastName?: string;
+        surname?: string;
         /**
          * A pseudo for the quiz author.
          */
@@ -263,6 +269,6 @@ declare namespace Quizoot {
          *
          * @pattern ^[a-zA-Z]+[\w.\d-]*@[a-zA-Z]+\.[a-zA-Z]{1,3}$
          */
-        email: string;
+        email?: string;
     }
 }


### PR DESCRIPTION
This PR is doing 2 things:
- create a `QuizPreview` component to display a quiz description and general information (see #32)
- implement a factory pattern to use the right component depending on the `QuestionKind`.

## Usage
To add a new Question: 
- update `schemas/interface.ts`
- then implement the corresponding component in `frontend/scr/components/questions`
- finally register your component in `frontend/scr/components/questions/QuestionWrapper.vue`

## What's next 
- [x] Implements each question component
- [x] The current usage can be tedious since we have an additional step (registering the question component). As a nice to have, we can do this dynamically by loading automatically every files in `frontend/scr/components/questions` except `QuestionWrapper` in the factory.


## Notes
I am not a Vuejs expert, so there might be a better way to do it