### PR TITLE
Add remaining methods for the `Quiz` crud interface

### DIFF
--- a/backend/api/exceptions.py
+++ b/backend/api/exceptions.py
@@ -4,3 +4,7 @@ class InvalidData(Exception):
 
 class InvalidCollection(Exception):
     pass
+
+
+class CollectionFull(Exception):
+    pass

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -3,10 +3,7 @@ from . import views
 
 urlpatterns = [
     path("", view=views.index, name="index"),
-    path("quizzes/", view=views.quiz_list, name="quizzes-list"),
-    path("quizzes/create/", view=views.quiz_create, name="quiz-create"),
-    path("quiz/<str:pk>/", view=views.quiz_details, name="quiz-details"),
-    path("quiz/<str:pk>/update/", view=views.quiz_update, name="quiz-update"),
-    path("quiz/<str:pk>/delete/", view=views.quiz_delete, name="quiz-delete"),
+    path("quizzes/", view=views.QuizList.as_view(), name="quizzes-list"),
+    path("quizzes/<str:pk>/", view=views.QuizDetails.as_view(), name="quiz-details"),
     path("questions/", view=views.question_list, name="questions-list"),
 ]

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -4,5 +4,9 @@ from . import views
 urlpatterns = [
     path("", view=views.index, name="index"),
     path("quizzes/", view=views.quiz_list, name="quizzes-list"),
+    path("quizzes/create/", view=views.quiz_create, name="quiz-create"),
+    path("quiz/<str:pk>/", view=views.quiz_details, name="quiz-details"),
+    path("quiz/<str:pk>/update/", view=views.quiz_update, name="quiz-update"),
+    path("quiz/<str:pk>/delete/", view=views.quiz_delete, name="quiz-delete"),
     path("questions/", view=views.question_list, name="questions-list"),
 ]

--- a/backend/api/utils.py
+++ b/backend/api/utils.py
@@ -35,8 +35,8 @@ def get_sort_order_from_request(
     request: Request, collection: __Collection
 ) -> List[Tuple[str, int]]:
 
-    sort_key: Any = request.query_params.get("sort_key", None)
-    sort_order: Any = request.query_params.get("sort_order", None)
+    sort_key = request.query_params.get("sort_key", None)
+    sort_order = request.query_params.get("sort_order", None)
 
     if sort_key is None:
         sort_key = DEFAULT_QUERY_LIST_SORT_KEY

--- a/backend/api/utils.py
+++ b/backend/api/utils.py
@@ -1,10 +1,69 @@
 import json
 from bson import json_util
-from typing import Any
+from typing import Any, List, Tuple, Type
 
+import pymongo
+from django.core.handlers.wsgi import WSGIRequest
 from rest_framework.response import Response
+
+from .exceptions import CollectionFull
+
+
+__Collection = type(Type[pymongo.collection.Collection])
+
+MIN_ID_VALUE = 100_000_000_000
+MAX_ID_VALUE = 999_999_999_999
+DEFAULT_QUERY_LIST_SORT_KEY = "id"
+DEFAULT_QUERY_LIST_SORT_ORDER = pymongo.ASCENDING
+QUERY_LIST_SORT_ORDER = {
+    "ascending": pymongo.ASCENDING,
+    "descending": pymongo.DESCENDING,
+}
+
+
+def _to_python_object(obj: Any) -> Any:
+    return json.loads(json_util.dumps(obj))
 
 
 class JsonResponse(Response):
     def __init__(self, data: Any, *args, **kwargs):
-        super().__init__(json.loads(json_util.dumps(data)), *args, **kwargs)
+        super().__init__(_to_python_object(data), *args, **kwargs)
+
+
+def get_sort_order_from_request(
+    request: WSGIRequest, collection: __Collection
+) -> List[Tuple[str, int]]:
+
+    sort_key: Any = request.query_params.get("sort_key", None)
+    sort_order: Any = request.query_params.get("sort_order", None)
+
+    if sort_key is None:
+        sort_key = DEFAULT_QUERY_LIST_SORT_KEY
+    else:
+        sort_key = str(sort_key).lower()
+        # TODO: Find a way to check if the sort_key in a valid key of the `collection`.
+
+    if sort_order is None:
+        sort_order = DEFAULT_QUERY_LIST_SORT_ORDER
+    else:
+        sort_order = QUERY_LIST_SORT_ORDER.get(
+            str(sort_order).lower(), DEFAULT_QUERY_LIST_SORT_ORDER
+        )
+
+    return [(sort_key, sort_order)]
+
+
+def get_new_id(collection: __Collection) -> str:
+    if collection.find_one() is None:
+        return str(MIN_ID_VALUE)
+    else:
+        current_max_id = _to_python_object(
+            collection.find().sort("id", pymongo.DESCENDING).limit(1)
+        )[0]["id"]
+
+        if int(current_max_id) < MAX_ID_VALUE:
+            return str(int(current_max_id) + 1)
+        else:
+            raise CollectionFull(
+                f"The {collection.name} is full! You can't create a new object."
+            )

--- a/backend/api/utils.py
+++ b/backend/api/utils.py
@@ -3,13 +3,14 @@ from bson import json_util
 from typing import Any, List, Tuple, Type
 
 import pymongo
-from django.core.handlers.wsgi import WSGIRequest
 from rest_framework.response import Response
+from rest_framework.request import Request
 
 from .exceptions import CollectionFull
 
 
 __Collection = type(Type[pymongo.collection.Collection])
+__ApiRequest = type(Type[Request])
 
 MIN_ID_VALUE = 100_000_000_000
 MAX_ID_VALUE = 999_999_999_999
@@ -31,7 +32,7 @@ class JsonResponse(Response):
 
 
 def get_sort_order_from_request(
-    request: WSGIRequest, collection: __Collection
+    request: Request, collection: __Collection
 ) -> List[Tuple[str, int]]:
 
     sort_key: Any = request.query_params.get("sort_key", None)

--- a/backend/api/validators.py
+++ b/backend/api/validators.py
@@ -9,10 +9,7 @@ from .exceptions import InvalidData, InvalidCollection
 
 class SchemaValidator:
     __schema_dir = settings.BASE_DIR / "interfaces/schemas"
-    __schema_names = {
-        "quizzes": "quiz.json",
-        "questions": "question.json"
-    }
+    __schema_names = {"quizzes": "quiz.json", "questions": "question.json"}
 
     def __init__(self, collection: Literal["quizzes", "questions"]) -> None:
         self._schema = None
@@ -20,7 +17,9 @@ class SchemaValidator:
             with open(self.__schema_dir / self.__schema_names[collection]) as file:
                 self._schema = json.load(file)
         else:
-            raise InvalidCollection("Collection must be literal 'quizzes' or 'questions")
+            raise InvalidCollection(
+                "Collection must be literal 'quizzes' or 'questions"
+            )
 
     def validate(self, data: Any) -> None:
         try:

--- a/backend/api/validators.py
+++ b/backend/api/validators.py
@@ -8,18 +8,17 @@ from .exceptions import InvalidData, InvalidCollection
 
 
 class SchemaValidator:
-    __schema_dir = settings.BASE_DIR / "interfaces/schemas"
-    __schema_names = {"quizzes": "quiz.json", "questions": "question.json"}
+    __schemas_base_dir = settings.BASE_DIR / "interfaces/schemas"
+    __schemas = {"quizzes": "quiz.json", "questions": "question.json"}
 
     def __init__(self, collection: Literal["quizzes", "questions"]) -> None:
-        self._schema = None
-        if collection in self.__schema_names.keys():
-            with open(self.__schema_dir / self.__schema_names[collection]) as file:
-                self._schema = json.load(file)
-        else:
-            raise InvalidCollection(
-                "Collection must be literal 'quizzes' or 'questions"
-            )
+        if collection not in self.__schemas:
+            raise InvalidCollection("Collection must be literal 'quizzes' or 'questions")
+
+        schema_path = self.__schemas_base_dir / self.__schemas[collection]
+
+        with schema_path.open() as file:
+            self._schema = json.load(file)
 
     def validate(self, data: Any) -> None:
         try:

--- a/backend/api/validators.py
+++ b/backend/api/validators.py
@@ -13,7 +13,9 @@ class SchemaValidator:
 
     def __init__(self, collection: Literal["quizzes", "questions"]) -> None:
         if collection not in self.__schemas:
-            raise InvalidCollection("Collection must be literal 'quizzes' or 'questions")
+            raise InvalidCollection(
+                "Collection must be literal 'quizzes' or 'questions"
+            )
 
         schema_path = self.__schemas_base_dir / self.__schemas[collection]
 

--- a/backend/api/validators.py
+++ b/backend/api/validators.py
@@ -9,26 +9,21 @@ from .exceptions import InvalidData, InvalidCollection
 
 class SchemaValidator:
     __schema_dir = settings.BASE_DIR / "interfaces/schemas"
+    __schema_names = {
+        "quizzes": "quiz.json",
+        "questions": "question.json"
+    }
 
-    def __init__(self) -> None:
-        self._quiz_schema = None
-        self._question_schema = None
+    def __init__(self, collection: Literal["quizzes", "questions"]) -> None:
+        self._schema = None
+        if collection in self.__schema_names.keys():
+            with open(self.__schema_dir / self.__schema_names[collection]) as file:
+                self._schema = json.load(file)
+        else:
+            raise InvalidCollection("Collection must be literal 'quizzes' or 'questions")
 
-        with open(self.__schema_dir / "quiz.json") as file:
-            self._quiz_schema = json.load(file)
-
-        with open(self.__schema_dir / "question.json") as file:
-            self._schema = json.load(file)
-
-    def validate(self, data: Any, collection: Literal["quizzes", "questions"]) -> None:
+    def validate(self, data: Any) -> None:
         try:
-            if collection == "quizzes":
-                jsonschema.validate(data, self._quiz_schema)
-            elif collection == "questions":
-                jsonschema.validate(data, self._question_schema)
-            else:
-                raise InvalidCollection(
-                    "Collection must be literal 'quizzes' or 'questions'"
-                )
+            jsonschema.validate(data, self._schema)
         except jsonschema.exceptions.ValidationError as err:
             raise InvalidData(err.message)

--- a/backend/api/views/index.py
+++ b/backend/api/views/index.py
@@ -5,7 +5,7 @@ from django.views.decorators.csrf import csrf_exempt
 
 from ..validators import SchemaValidator
 
-validator = SchemaValidator()
+validator = SchemaValidator("quizzes")
 
 
 @csrf_exempt
@@ -16,7 +16,7 @@ def index(request):
         json_data = json.loads(data.decode("utf8"))
 
         # Validate data
-        validator.validate(json_data, "quizzes")
+        validator.validate(json_data)
 
         # Do something else
         print("Valid question :", json_data)

--- a/backend/api/views/quiz.py
+++ b/backend/api/views/quiz.py
@@ -1,7 +1,6 @@
-import json
-
-from django.conf import settings
-from rest_framework.decorators import api_view
+from django.http import Http404
+from rest_framework.views import APIView
+from rest_framework.request import Request
 from rest_framework import status
 from pymongo.collection import ReturnDocument
 
@@ -11,100 +10,71 @@ from ..utils import JsonResponse, get_sort_order_from_request, get_new_id
 from ..exceptions import InvalidData
 
 
-__quizzes_collection = client.collection("quizzes")
-__quiz_validator = SchemaValidator()
+class QuizList(APIView):
+    __quizzes = client.collection("quizzes")
+    __validator = SchemaValidator("quizzes")
 
+    def get(self, request: Request) -> JsonResponse:
+        sort_order = get_sort_order_from_request(request, self.__quizzes)
+        return JsonResponse(data=self.__quizzes.find(sort=sort_order))
 
-@api_view(["GET"])
-def quiz_list(request) -> JsonResponse:
-    if request.method == "GET":
-        sort_order = get_sort_order_from_request(request, __quizzes_collection)
-        return JsonResponse(data=__quizzes_collection.find(sort=sort_order))
-
-
-@api_view(["GET", "POST"])
-def quiz_create(request) -> JsonResponse:
-    if request.method == "GET":
-        with open(settings.BASE_DIR / "interfaces/schemas/quiz.json") as file:
-            quiz_schema = json.loads(file.read())
-            # Display the schema on the create view as a template
-            return JsonResponse(data=quiz_schema)
-
-    elif request.method == "POST":
+    def post(self, request: Request) -> JsonResponse:
         quiz_data = request.data
-        quiz_data["id"] = get_new_id(__quizzes_collection)
+        quiz_data["id"] = get_new_id(self.__quizzes)
 
         try:
-            __quiz_validator.validate(quiz_data, "quizzes")
+            self.__validator.validate(quiz_data)
         except InvalidData as error:
             return JsonResponse(
                 data={"message": f"Invalid JSON: {str(error)}"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
         else:
-            insertion_result = __quizzes_collection.insert_one(quiz_data)
-            inserted_quiz = __quizzes_collection.find_one(
+            insertion_result = self.__quizzes.insert_one(quiz_data)
+            inserted_quiz = self.__quizzes.find_one(
                 {"_id": insertion_result.inserted_id}
             )
             return JsonResponse(data=inserted_quiz, status=status.HTTP_201_CREATED)
 
 
-@api_view(["GET"])
-def quiz_details(request, pk: str) -> JsonResponse:
-    if request.method == "GET":
-        quiz = __quizzes_collection.find_one({"id": pk})
+class QuizDetails(APIView):
+    __collection = client.collection("quizzes")
+    __validator = SchemaValidator("quizzes")
 
-        if quiz is None:
-            return JsonResponse(
-                data={"message": "There is no quiz matching your query."},
-                status=status.HTTP_404_NOT_FOUND,
-            )
-        else:
-            return JsonResponse(data=quiz)
-
-
-@api_view(["GET", "POST"])
-def quiz_update(request, pk: str) -> JsonResponse:
-    if request.method == "GET":
-        quiz_to_update = __quizzes_collection.find_one({"id": pk})
-        return JsonResponse(data=quiz_to_update)
-
-    elif request.method == "POST":
-        quiz_data = request.data
-
-        try:
-            __quiz_validator.validate(quiz_data, "quizzes")
-        except InvalidData as error:
-            return JsonResponse(
-                data={"message": f"Invalid JSON: {str(error)}"},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-        else:
-            updated_quiz = __quizzes_collection.find_one_and_update(
-                {"id": pk},
-                {"$set": quiz_data},
-                # If the document is not already in collection, insert it
-                upsert=True,
-                # Return the updated document
-                return_document=ReturnDocument.AFTER,
-            )
-            return JsonResponse(data=updated_quiz)
-
-
-@api_view(["GET", "DELETE"])
-def quiz_delete(request, pk: str) -> JsonResponse:
-    quiz_to_delete = __quizzes_collection.find_one({"id": pk})
-
-    if quiz_to_delete is None:
-        return JsonResponse(
-            data={"message": "There is no quiz matching your query."},
-            status=status.HTTP_404_NOT_FOUND,
-        )
-    else:
+    def get(self, request: Request, pk: str) -> JsonResponse:
         if request.method == "GET":
-            return JsonResponse(data=quiz_to_delete)
-        elif request.method == "DELETE":
-            __quizzes_collection.find_one_and_delete({"id": pk})
+            quiz = self.__collection.find_one({"id": pk})
+
+            if quiz is None:
+                raise Http404("There is no quiz matching your query.")
+            else:
+                return JsonResponse(data=quiz)
+
+    def patch(self, request: Request, pk: str) -> JsonResponse:
+        if request.method == "PATCH":
+            quiz_data = request.data
+
+            try:
+                self.__validator.validate(quiz_data)
+            except InvalidData as error:
+                return JsonResponse(
+                    data={"message": f"Invalid JSON: {str(error)}"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            else:
+                updated_quiz = self.__collection.find_one_and_update(
+                    {"id": pk},
+                    {"$set": quiz_data},
+                    # If the document is not already in collection, insert it
+                    upsert=True,
+                    # Return the updated document
+                    return_document=ReturnDocument.AFTER,
+                )
+                return JsonResponse(data=updated_quiz)
+
+    def delete(self, request: Request, pk: str) -> JsonResponse:
+        if request.method == "DELETE":
+            self.__collection.find_one_and_delete({"id": pk})
             return JsonResponse(
                 data={}
             )  # An empty JSON is returned, as to confirm deletion

--- a/backend/api/views/quiz.py
+++ b/backend/api/views/quiz.py
@@ -46,7 +46,7 @@ def quiz_create(request) -> JsonResponse:
             inserted_quiz = __quizzes_collection.find_one(
                 {"_id": insertion_result.inserted_id}
             )
-            return JsonResponse(data=inserted_quiz)
+            return JsonResponse(data=inserted_quiz, status=status.HTTP_201_CREATED)
 
 
 @api_view(["GET"])
@@ -107,4 +107,4 @@ def quiz_delete(request, pk: str) -> JsonResponse:
             __quizzes_collection.find_one_and_delete({"id": pk})
             return JsonResponse(
                 data={}
-            )  # An empty JSON is returned as to confirm deletion
+            )  # An empty JSON is returned, as to confirm deletion

--- a/backend/api/views/quiz.py
+++ b/backend/api/views/quiz.py
@@ -1,10 +1,110 @@
-from rest_framework.decorators import api_view
+import json
 
+from django.conf import settings
+from rest_framework.decorators import api_view
+from rest_framework import status
+from pymongo.collection import ReturnDocument
+
+from ..validators import SchemaValidator
 from ..client import client
-from ..utils import JsonResponse
+from ..utils import JsonResponse, get_sort_order_from_request, get_new_id
+from ..exceptions import InvalidData
+
+
+__quizzes_collection = client.collection("quizzes")
+__quiz_validator = SchemaValidator()
 
 
 @api_view(["GET"])
-def quiz_list(request):
+def quiz_list(request) -> JsonResponse:
     if request.method == "GET":
-        return JsonResponse(data=client.collection("quizzes").find())
+        sort_order = get_sort_order_from_request(request, __quizzes_collection)
+        return JsonResponse(data=__quizzes_collection.find(sort=sort_order))
+
+
+@api_view(["GET", "POST"])
+def quiz_create(request) -> JsonResponse:
+    if request.method == "GET":
+        with open(settings.BASE_DIR / "interfaces/schemas/quiz.json") as file:
+            quiz_schema = json.loads(file.read())
+            # Display the schema on the create view as a template
+            return JsonResponse(data=quiz_schema)
+
+    elif request.method == "POST":
+        quiz_data = request.data
+        quiz_data["id"] = get_new_id(__quizzes_collection)
+
+        try:
+            __quiz_validator.validate(quiz_data, "quizzes")
+        except InvalidData as error:
+            return JsonResponse(
+                data={"message": f"Invalid JSON: {str(error)}"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        else:
+            insertion_result = __quizzes_collection.insert_one(quiz_data)
+            inserted_quiz = __quizzes_collection.find_one(
+                {"_id": insertion_result.inserted_id}
+            )
+            return JsonResponse(data=inserted_quiz)
+
+
+@api_view(["GET"])
+def quiz_details(request, pk: str) -> JsonResponse:
+    if request.method == "GET":
+        quiz = __quizzes_collection.find_one({"id": pk})
+
+        if quiz is None:
+            return JsonResponse(
+                data={"message": "There is no quiz matching your query."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        else:
+            return JsonResponse(data=quiz)
+
+
+@api_view(["GET", "POST"])
+def quiz_update(request, pk: str) -> JsonResponse:
+    if request.method == "GET":
+        quiz_to_update = __quizzes_collection.find_one({"id": pk})
+        return JsonResponse(data=quiz_to_update)
+
+    elif request.method == "POST":
+        quiz_data = request.data
+
+        try:
+            __quiz_validator.validate(quiz_data, "quizzes")
+        except InvalidData as error:
+            return JsonResponse(
+                data={"message": f"Invalid JSON: {str(error)}"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        else:
+            updated_quiz = __quizzes_collection.find_one_and_update(
+                {"id": pk},
+                {"$set": quiz_data},
+                # If the document is not already in collection, insert it
+                upsert=True,
+                # Return the updated document
+                return_document=ReturnDocument.AFTER,
+            )
+            return JsonResponse(data=updated_quiz)
+
+
+@api_view(["GET", "DELETE"])
+def quiz_delete(request, pk: str) -> JsonResponse:
+    quiz_to_delete = __quizzes_collection.find_one({"id": pk})
+
+    if quiz_to_delete is None:
+        return JsonResponse(
+            data={"message": "There is no quiz matching your query."},
+            status=status.HTTP_404_NOT_FOUND,
+        )
+    else:
+        if request.method == "GET":
+            return JsonResponse(data=quiz_to_delete)
+        elif request.method == "DELETE":
+            __quizzes_collection.find_one_and_delete({"id": pk})
+            return JsonResponse(
+                data={}
+            )  # An empty JSON is returned as to confirm deletion

--- a/backend/api/views/quiz.py
+++ b/backend/api/views/quiz.py
@@ -38,12 +38,12 @@ class QuizList(APIView):
 
 
 class QuizDetails(APIView):
-    __collection = client.collection("quizzes")
+    __quizzes = client.collection("quizzes")
     __validator = SchemaValidator("quizzes")
 
     def get(self, request: Request, pk: str) -> JsonResponse:
         if request.method == "GET":
-            quiz = self.__collection.find_one({"id": pk})
+            quiz = self.__quizzes.find_one({"id": pk})
 
             if quiz is None:
                 raise Http404("There is no quiz matching your query.")
@@ -62,7 +62,7 @@ class QuizDetails(APIView):
                     status=status.HTTP_400_BAD_REQUEST,
                 )
             else:
-                updated_quiz = self.__collection.find_one_and_update(
+                updated_quiz = self.__quizzes.find_one_and_update(
                     {"id": pk},
                     {"$set": quiz_data},
                     # If the document is not already in collection, insert it
@@ -74,7 +74,7 @@ class QuizDetails(APIView):
 
     def delete(self, request: Request, pk: str) -> JsonResponse:
         if request.method == "DELETE":
-            self.__collection.find_one_and_delete({"id": pk})
+            self.__quizzes.find_one_and_delete({"id": pk})
             return JsonResponse(
                 data={}
             )  # An empty JSON is returned, as to confirm deletion

--- a/frontend/src/components/questions/UploadQuestion.vue
+++ b/frontend/src/components/questions/UploadQuestion.vue
@@ -118,13 +118,14 @@ function onFileAdd(event: HTMLInputEvent | DragEvent) {
     display: flex;
     flex-direction: column;
     gap: 20px;
-    margin-block: 50px;
+    margin-bottom: 25px;
+    width: 75%;
 }
 
 .upload-question-container > * {
     margin-inline: 50%;
     transform: translateX(-50%);
-    width: 70%;
+    width: 100%;
 }
 
 .allowed-info {
@@ -197,6 +198,16 @@ function onFileAdd(event: HTMLInputEvent | DragEvent) {
 }
 
 @media only screen and (max-width: 600px) {
+    .upload-question-container {
+        width: 100%;
+    }
+
+    .allowed-info {
+        flex-direction: column;
+        text-align: left;
+        padding-left: 60px;
+    }
+
     .drag-drop-outer {
         width: 90%;
     }


### PR DESCRIPTION
Related to #20 

## Suggestion

What if we specify the `collection` directly when instanciating the `SchemaValidator` ? 
We will then have something like this, and avoid repeating the collection name thoughout each view file:

```python3
# backend/api/validator.py
class SchemaValidator:
    __schema_dir = settings.BASE_DIR / "interfaces/schemas"
    __schema_names = {
        "quizzes": "quiz.json",
        "questions": "question.json"
    }

    def __init__(self, collection: Literal["quizzes", "questions"]) -> None:
        self._schema = None
        if collection in __schema_names.keys():
            with open(self.__schema_dir / __schema_names[collection]) as file:
                self._schema = json.load(file)
        else:
            raise InvalidCollection("Collection must be literal 'quizzes' or 'questions")
    
    def validate(self, data: Any) -> None:
        try:
            jsonschema.validate(data, self._schema)
        except jsonschema.exceptions.ValidationError as err:
            raise InvalidData(err.message)
```

```python3
# backend/api/views/quiz.py
...
__quiz_validator = SchemaValidator("quizzes")

def quiz_something(request) -> JsonResponse:
    ...
    __quiz_validator.validate(quiz_data)
    ...
```

## More

Maybe we will need more methods, I don't know. Tell me if you have any in mind.