### PR TITLE
Add `Vue-x`

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,8 @@
         "@fortawesome/vue-fontawesome": "^3.0.1",
         "axios": "^1.2.1",
         "vue": "^3.2.38",
-        "vue-router": "4"
+        "vue-router": "4",
+        "vuex": "^4.0.2"
     },
     "devDependencies": {
         "@rushstack/eslint-patch": "^1.1.4",

--- a/frontend/src/data/quiz-data-types.json
+++ b/frontend/src/data/quiz-data-types.json
@@ -1,5 +1,5 @@
 {
-    "id": "123456789012",
+    "id": "123456789000123456789012",
     "title": "Basic Data Types in Python",
     "description": "Test your understanding of the basic data types that are built into Python, like numbers, strings, and Booleans.",
     "max_score": 13,
@@ -12,7 +12,7 @@
     "tags": [],
     "questions": [
         {
-            "id": "123456789000",
+            "id": "123456789000123456789000",
             "kind": "CHOICE_QUESTION",
             "question": "Which of the following are valid ways to specify the string literal foo'bar in Python ?",
             "spec": {
@@ -51,7 +51,7 @@
             "hint": ""
         },
         {
-            "id": "123456789001",
+            "id": "123456789000123456789001",
             "kind": "TEXT_QUESTION",
             "question": "Write an expression for a string literal consisting of the following ASCII characters",
             "spec": {
@@ -69,7 +69,7 @@
             "hint": "'\\t' is the escape sequence for the Horizontal Tab character.\n\n'\\n' is the escape sequence for the Newline character.\n\nTo specify a character by hexadecimal value, use '\\xhh', where hh specifies the hexadecimal digits."
         },
         {
-            "id": "123456789002",
+            "id": "123456789000123456789002",
             "kind": "CODE_QUESTION",
             "question": "Use list comprehension to get the list ['ad', 'ae', 'bd', 'be', 'cd', 'ce'] from the two strings 'abc' and 'de'.",
             "spec": {
@@ -88,7 +88,7 @@
             "hint": "Use two nested 'for' loops."
         },
         {
-            "id": "123456789003",
+            "id": "123456789000123456789003",
             "kind": "UPLOAD_QUESTION",
             "question": "Write or generate programmatically a '.csv' file of 15 lines, using a suitable separator.\nUpload you answer file here (and the code file, if done programmatically).",
             "spec": {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,10 +1,12 @@
 import App from '@/App.vue';
 import { createApp } from 'vue';
 import router from '@/router';
+import { store, key } from './store/store';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import '@/lib/init_font_awesome';
 
 createApp(App)
     .use(router)
+    .use(store, key)
     .component('font-awesome-icon', FontAwesomeIcon)
     .mount('#app');

--- a/frontend/src/store/mutations.ts
+++ b/frontend/src/store/mutations.ts
@@ -1,0 +1,13 @@
+import type { MutationTree } from 'vuex';
+import type { State } from '@/store/state';
+import { MutationTypes } from '@/store/types';
+
+export type Mutations<S = State> = {
+    [MutationTypes.UPDATE_QUIZZES](state: S, quizzesList: State['quizzes']): void;
+}
+
+export const mutations: MutationTree<State> & Mutations = {
+    [MutationTypes.UPDATE_QUIZZES](state, quizzesList: State['quizzes']) {
+        state.quizzes = quizzesList
+    }
+}

--- a/frontend/src/store/mutations.ts
+++ b/frontend/src/store/mutations.ts
@@ -3,11 +3,14 @@ import type { State } from '@/store/state';
 import { MutationTypes } from '@/store/types';
 
 export type Mutations<S = State> = {
-    [MutationTypes.UPDATE_QUIZZES](state: S, quizzesList: State['quizzes']): void;
-}
+    [MutationTypes.UPDATE_QUIZZES](
+        state: S,
+        quizzesList: State['quizzes']
+    ): void;
+};
 
 export const mutations: MutationTree<State> & Mutations = {
     [MutationTypes.UPDATE_QUIZZES](state, quizzesList: State['quizzes']) {
-        state.quizzes = quizzesList
-    }
-}
+        state.quizzes = quizzesList;
+    },
+};

--- a/frontend/src/store/state.ts
+++ b/frontend/src/store/state.ts
@@ -2,8 +2,8 @@ import type { Quiz } from '@interfaces/quizoot.indexed';
 
 export const state = {
     quizzes: null,
-}
+};
 
 export type State = {
-    quizzes: Quiz[] | null
-}
+    quizzes: Quiz[] | null;
+};

--- a/frontend/src/store/state.ts
+++ b/frontend/src/store/state.ts
@@ -1,0 +1,9 @@
+import type { Quiz } from '@interfaces/quizoot.indexed';
+
+export const state = {
+    quizzes: null,
+}
+
+export type State = {
+    quizzes: Quiz[] | null
+}

--- a/frontend/src/store/store.ts
+++ b/frontend/src/store/store.ts
@@ -1,0 +1,28 @@
+import type { InjectionKey } from 'vue';
+import { createStore, useStore as baseUseStore } from 'vuex';
+import type { Store as BaseStore, CommitOptions } from 'vuex';
+import { state } from '@/store/state';
+import type { State } from '@/store/state';
+import { mutations } from '@/store/mutations';
+import type { Mutations } from '@/store/mutations';
+
+export const store = createStore({
+    state,
+    // getters,
+    mutations,
+});
+
+export const key: InjectionKey<BaseStore<State>> = Symbol();
+
+export type Store = Omit<BaseStore<State>, 'getters' | 'commit'>
+    & {
+    commit<K extends keyof Mutations, P extends Parameters<Mutations[K]>[1]>(
+        key: K,
+        payload: P,
+        options?: CommitOptions
+    ): ReturnType<Mutations[K]>
+}
+
+export function useStore() {
+    return baseUseStore(key);
+}

--- a/frontend/src/store/store.ts
+++ b/frontend/src/store/store.ts
@@ -14,14 +14,13 @@ export const store = createStore({
 
 export const key: InjectionKey<BaseStore<State>> = Symbol();
 
-export type Store = Omit<BaseStore<State>, 'getters' | 'commit'>
-    & {
+export type Store = Omit<BaseStore<State>, 'getters' | 'commit'> & {
     commit<K extends keyof Mutations, P extends Parameters<Mutations[K]>[1]>(
         key: K,
         payload: P,
         options?: CommitOptions
-    ): ReturnType<Mutations[K]>
-}
+    ): ReturnType<Mutations[K]>;
+};
 
 export function useStore() {
     return baseUseStore(key);

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -1,0 +1,3 @@
+export enum MutationTypes {
+    UPDATE_QUIZZES = 'UPDATE_QUIZZES',
+}

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -14,14 +14,14 @@ const store = useStore();
 
 if (!store.state.quizzes) {
     useFetch<Quiz[]>('/api/quizzes')
-        .then(response => {
+        .then((response) => {
             if (response.error.value) {
                 log(response.error.value);
             }
 
             store.commit(MutationTypes.UPDATE_QUIZZES, response.data.value);
         })
-        .catch(error => log(error))
+        .catch((error) => log(error));
 }
 
 const quizzes: ComputedRef<Quiz[] | null> = computed(() => store.state.quizzes);
@@ -41,7 +41,6 @@ function goToQuiz(quizId: number) {
         <div v-for="quiz in quizzes" :key="quiz">
             <QuizCard @click="goToQuiz(quiz.id)" />
         </div>
-
     </div>
 </template>
 

--- a/frontend/src/vuex.d.ts
+++ b/frontend/src/vuex.d.ts
@@ -1,0 +1,7 @@
+import { Store } from '@/store/store';
+
+declare module '@vue/runtime-core' {
+    interface ComponentCustomProperties {
+        $store: Store;
+    }
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -674,6 +674,11 @@
     "@vue/compiler-dom" "3.2.45"
     "@vue/shared" "3.2.45"
 
+"@vue/devtools-api@^6.0.0-beta.11":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@vue/devtools-api/-/devtools-api-6.5.0.tgz#98b99425edee70b4c992692628fa1ea2c1e57d07"
+  integrity sha512-o9KfBeaBmCKl10usN4crU53fYtC1r7jJwdGKjPT24t348rHxgfpZ0xL3Xm/gLUYnc0oTp8LAmrxOeLyu6tbk2Q==
+
 "@vue/devtools-api@^6.4.5":
   version "6.4.5"
   resolved "https://registry.yarnpkg.com/@vue/devtools-api/-/devtools-api-6.4.5.tgz#d54e844c1adbb1e677c81c665ecef1a2b4bb8380"
@@ -2785,6 +2790,13 @@ vue@^3.2.38:
     "@vue/runtime-dom" "3.2.45"
     "@vue/server-renderer" "3.2.45"
     "@vue/shared" "3.2.45"
+
+vuex@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/vuex/-/vuex-4.0.2.tgz#f896dbd5bf2a0e963f00c67e9b610de749ccacc9"
+  integrity sha512-M6r8uxELjZIK8kTKDGgZTYX/ahzblnzC4isU1tpmEuOIIKmV+TRdc+H4s8ds2NuZ7wpUTdGRzJRtoj+lI+pc0Q==
+  dependencies:
+    "@vue/devtools-api" "^6.0.0-beta.11"
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This PR adds `vue-x` for a global state management. See [the doc](https://vuex.vuejs.org/)

 ## Why

The main usage is to store the fetched quizzes (at the `Home` commponent first loading).

The quizzes can then be retrieved from the store at further returns to the `Home page`, without any fetch.

The same behavior will be add to the current quiz in the `Quiz` view.

## Details

I refered to [this article](https://dev.to/3vilarthas/vuex-typescript-m4j) for the typing