### PR TITLE
Add endpoints for `Questions`

### DIFF
--- a/backend/api/admin.py
+++ b/backend/api/admin.py
@@ -1,3 +1,0 @@
-from django.contrib import admin
-
-# Register your models here.

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -5,5 +5,6 @@ urlpatterns = [
     path("", view=views.index, name="index"),
     path("quizzes/", view=views.QuizList.as_view(), name="quizzes-list"),
     path("quizzes/<str:pk>/", view=views.QuizDetail.as_view(), name="quiz-details"),
-    path("questions/", view=views.question_list, name="questions-list"),
+    path("questions/", view=views.QuestionList.as_view(), name="questions-list"),
+    path("questions/<str:pk>/", view=views.QuestionDetail.as_view(), name="question-details"),
 ]

--- a/backend/api/views/question.py
+++ b/backend/api/views/question.py
@@ -1,10 +1,77 @@
-from rest_framework.decorators import api_view
+from django.http import Http404
+from pymongo.collection import ReturnDocument
+from rest_framework import status
+from rest_framework.request import Request
+from rest_framework.views import APIView
 
 from ..client import client
-from ..utils import JsonResponse
+from ..exceptions import InvalidData
+from ..utils import JsonResponse, get_new_id, get_sort_order
+from ..validators import SchemaValidator
 
 
-@api_view(["GET"])
-def question_list(request):
-    if request.method == "GET":
-        return JsonResponse(data=client.collection("questions").find())
+class QuestionApiView(APIView):
+    _questions = client.collection("questions")
+    _validator = SchemaValidator("questions")
+
+
+class QuestionList(QuestionApiView):
+    """LIST all questions and CREATE new question."""
+
+    def get(self, request: Request):
+        sort_order = get_sort_order(request.query_params, self._questions)
+        return JsonResponse(data=self._questions.find(sort=sort_order))
+
+    def post(self, request: Request):
+        question_data = request.data
+        question_data["id"] = get_new_id()
+
+        try:
+            self._validator.validate(question_data)
+        except InvalidData as error:
+            return JsonResponse(
+                data={"message": f"Invalid JSON: {str(error)}"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        else:
+            insertion_result = self._questions.insert_one(question_data)
+            inserted_question = self._questions.find_one(
+                {"_id": insertion_result.inserted_id}
+            )
+            return JsonResponse(data=inserted_question, status=status.HTTP_201_CREATED)
+
+
+class QuestionDetail(QuestionApiView):
+    """GET, PATCH and DELETE a single question."""
+
+    def get(self, request: Request, pk: str):
+        question = self._questions.find_one({"id": pk})
+
+        if question is None:
+            raise Http404("There is no question matching your query.")
+        else:
+            return JsonResponse(data=question)
+
+    def patch(self, request: Request, pk: str) -> JsonResponse:
+        question_data = request.data
+
+        try:
+            self._validator.validate(question_data)
+        except InvalidData as error:
+            return JsonResponse(
+                data={"message": f"Invalid JSON: {str(error)}"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        else:
+            updated_question = self._questions.find_one_and_update(
+                {"id": pk},
+                {"$set": question_data},
+                # Return the updated document
+                return_document=ReturnDocument.AFTER,
+            )
+            return JsonResponse(data=updated_question)
+
+    def delete(self, request: Request, pk: str) -> JsonResponse:
+        self._questions.find_one_and_delete({"id": pk})
+        # A JSON with the deleted item id is returned, as to confirm deletion
+        return JsonResponse(data={"id": pk})

--- a/backend/api/views/question.py
+++ b/backend/api/views/question.py
@@ -1,77 +1,10 @@
-from django.http import Http404
-from pymongo.collection import ReturnDocument
-from rest_framework import status
-from rest_framework.request import Request
-from rest_framework.views import APIView
+from .views import ListView, DetailView
 
-from ..client import client
-from ..exceptions import InvalidData
-from ..utils import JsonResponse, get_new_id, get_sort_order
-from ..validators import SchemaValidator
+class QuestionList(ListView):
+    def __init__(self):
+        super().__init__('questions')
 
 
-class QuestionApiView(APIView):
-    _questions = client.collection("questions")
-    _validator = SchemaValidator("questions")
-
-
-class QuestionList(QuestionApiView):
-    """LIST all questions and CREATE new question."""
-
-    def get(self, request: Request):
-        sort_order = get_sort_order(request.query_params, self._questions)
-        return JsonResponse(data=self._questions.find(sort=sort_order))
-
-    def post(self, request: Request):
-        question_data = request.data
-        question_data["id"] = get_new_id()
-
-        try:
-            self._validator.validate(question_data)
-        except InvalidData as error:
-            return JsonResponse(
-                data={"message": f"Invalid JSON: {str(error)}"},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-        else:
-            insertion_result = self._questions.insert_one(question_data)
-            inserted_question = self._questions.find_one(
-                {"_id": insertion_result.inserted_id}
-            )
-            return JsonResponse(data=inserted_question, status=status.HTTP_201_CREATED)
-
-
-class QuestionDetail(QuestionApiView):
-    """GET, PATCH and DELETE a single question."""
-
-    def get(self, request: Request, pk: str):
-        question = self._questions.find_one({"id": pk})
-
-        if question is None:
-            raise Http404("There is no question matching your query.")
-        else:
-            return JsonResponse(data=question)
-
-    def patch(self, request: Request, pk: str) -> JsonResponse:
-        question_data = request.data
-
-        try:
-            self._validator.validate(question_data)
-        except InvalidData as error:
-            return JsonResponse(
-                data={"message": f"Invalid JSON: {str(error)}"},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-        else:
-            updated_question = self._questions.find_one_and_update(
-                {"id": pk},
-                {"$set": question_data},
-                # Return the updated document
-                return_document=ReturnDocument.AFTER,
-            )
-            return JsonResponse(data=updated_question)
-
-    def delete(self, request: Request, pk: str) -> JsonResponse:
-        self._questions.find_one_and_delete({"id": pk})
-        # A JSON with the deleted item id is returned, as to confirm deletion
-        return JsonResponse(data={"id": pk})
+class QuestionDetail(DetailView):
+    def __init__(self):
+        super().__init__('questions')

--- a/backend/api/views/quiz.py
+++ b/backend/api/views/quiz.py
@@ -1,77 +1,10 @@
-from django.http import Http404
-from pymongo.collection import ReturnDocument
-from rest_framework import status
-from rest_framework.request import Request
-from rest_framework.views import APIView
+from .views import ListView, DetailView
 
-from ..client import client
-from ..exceptions import InvalidData
-from ..utils import JsonResponse, get_new_id, get_sort_order
-from ..validators import SchemaValidator
+class QuizList(ListView):
+    def __init__(self):
+        super().__init__('quizzes')
 
 
-class QuizApiView(APIView):
-    _quizzes = client.collection("quizzes")
-    _validator = SchemaValidator("quizzes")
-
-
-class QuizList(QuizApiView):
-    """LIST all quizzes and CREATE new quiz."""
-
-    def get(self, request: Request):
-        sort_order = get_sort_order(request.query_params, self._quizzes)
-        return JsonResponse(data=self._quizzes.find(sort=sort_order))
-
-    def post(self, request: Request):
-        quiz_data = request.data
-        quiz_data["id"] = get_new_id()
-
-        try:
-            self._validator.validate(quiz_data)
-        except InvalidData as error:
-            return JsonResponse(
-                data={"message": f"Invalid JSON: {str(error)}"},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-        else:
-            insertion_result = self._quizzes.insert_one(quiz_data)
-            inserted_quiz = self._quizzes.find_one(
-                {"_id": insertion_result.inserted_id}
-            )
-            return JsonResponse(data=inserted_quiz, status=status.HTTP_201_CREATED)
-
-
-class QuizDetail(QuizApiView):
-    """GET, PATCH and DELETE a single quiz."""
-
-    def get(self, request: Request, pk: str):
-        quiz = self._quizzes.find_one({"id": pk})
-
-        if quiz is None:
-            raise Http404("There is no quiz matching your query.")
-        else:
-            return JsonResponse(data=quiz)
-
-    def patch(self, request: Request, pk: str) -> JsonResponse:
-        quiz_data = request.data
-
-        try:
-            self._validator.validate(quiz_data)
-        except InvalidData as error:
-            return JsonResponse(
-                data={"message": f"Invalid JSON: {str(error)}"},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-        else:
-            updated_quiz = self._quizzes.find_one_and_update(
-                {"id": pk},
-                {"$set": quiz_data},
-                # Return the updated document
-                return_document=ReturnDocument.AFTER,
-            )
-            return JsonResponse(data=updated_quiz)
-
-    def delete(self, request: Request, pk: str) -> JsonResponse:
-        self._quizzes.find_one_and_delete({"id": pk})
-        # A JSON with the deleted item id is returned, as to confirm deletion
-        return JsonResponse(data={"id": pk})
+class QuizDetail(DetailView):
+    def __init__(self):
+        super().__init__('quizzes')

--- a/backend/api/views/views.py
+++ b/backend/api/views/views.py
@@ -1,0 +1,87 @@
+from typing import Literal
+
+from django.http import Http404
+from pymongo.collection import ReturnDocument
+from rest_framework import status
+from rest_framework.request import Request
+from rest_framework.views import APIView
+
+from ..client import client
+from ..exceptions import InvalidData
+from ..utils import JsonResponse, get_new_id, get_sort_order
+from ..validators import SchemaValidator
+
+
+class GenericApiView(APIView):
+    def __init__(self, collection_name: Literal['quizzes', 'questions']):
+        super().__init__()
+        self._collection = client.collection(collection_name)
+        self._validator = SchemaValidator(collection_name)
+
+
+class ListView(GenericApiView):
+    """LIST all documents and CREATE new document."""
+
+    def __init__(self, collection_name: Literal['quizzes', 'questions']):
+        super().__init__(collection_name)
+
+    def get(self, request: Request):
+        sort_order = get_sort_order(request.query_params, self._collection)
+        return JsonResponse(data=self._collection.find(sort=sort_order))
+
+    def post(self, request: Request):
+        data = request.data
+        data["id"] = get_new_id()
+
+        try:
+            self._validator.validate(data)
+        except InvalidData as error:
+            return JsonResponse(
+                data={"message": f"Invalid JSON: {str(error)}"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        else:
+            insertion_result = self._collection.insert_one(data)
+            inserted_data = self._collection.find_one(
+                {"_id": insertion_result.inserted_id}
+            )
+            return JsonResponse(data=inserted_data, status=status.HTTP_201_CREATED)
+
+
+class DetailView(GenericApiView):
+    """GET, PATCH and DELETE a single document."""
+
+    def __init__(self, collection_name: Literal['quizzes', 'questions']):
+        super().__init__(collection_name)
+
+    def get(self, request: Request, pk: str):
+        document = self._collection.find_one({"id": pk})
+
+        if document is None:
+            raise Http404("There is no document matching your query.")
+        else:
+            return JsonResponse(data=document)
+
+    def patch(self, request: Request, pk: str) -> JsonResponse:
+        data = request.data
+
+        try:
+            self._validator.validate(data)
+        except InvalidData as error:
+            return JsonResponse(
+                data={"message": f"Invalid JSON: {str(error)}"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        else:
+            updated_data = self._collection.find_one_and_update(
+                {"id": pk},
+                {"$set": data},
+                # Return the updated document
+                return_document=ReturnDocument.AFTER,
+            )
+            return JsonResponse(data=updated_data)
+
+    def delete(self, request: Request, pk: str) -> JsonResponse:
+        self._collection.find_one_and_delete({"id": pk})
+        # A JSON with the deleted item id is returned, as to confirm deletion
+        return JsonResponse(data={"id": pk})


### PR DESCRIPTION
* Resolves #20 
<hr>

This PR adds the `QuestionList` and `QuestionDetail` api views.

As `question.py` and `quiz.py` uses the exact same logic, I also add a file `views.py` containing generic `ListView` and `DetailView` views, which only have to be used with the adequate `collection_name`.