### PR TITLE
Improve the `Questions` fetching

### DIFF
--- a/frontend/src/components/FetchError.vue
+++ b/frontend/src/components/FetchError.vue
@@ -1,0 +1,31 @@
+<template>
+    <div class="fetch-error">
+        <font-awesome-icon
+            icon="fa-solid fa-triangle-exclamation"
+            size="2xl"
+            color="var(--main-purple-lightened)"
+            class="warning-icon"
+        />
+        <br />
+        <p>Sorry, something went wrong...</p>
+    </div>
+</template>
+
+<style scoped>
+.fetch-error {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 50vh;
+}
+
+.warning-icon {
+    font-size: 4em;
+}
+
+p {
+    font-style: italic;
+}
+</style>

--- a/frontend/src/components/Loader.vue
+++ b/frontend/src/components/Loader.vue
@@ -1,0 +1,35 @@
+<template>
+    <div class="loader">
+        <font-awesome-icon
+            icon="fa-solid fa-spinner"
+            size="2xl"
+            color="var(--main-purple-lightened)"
+            class="spinner"
+        />
+        <p>Loading...</p>
+    </div>
+</template>
+
+<style scoped>
+.loader {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 50vh;
+}
+
+.spinner {
+    animation: spin 1.65s linear infinite;
+}
+
+@keyframes spin {
+    from {
+        transform: rotate(0deg);
+    }
+
+    to {
+        transform: rotate(360deg);
+    }
+}
+</style>

--- a/frontend/src/components/Question.vue
+++ b/frontend/src/components/Question.vue
@@ -8,7 +8,6 @@ import { pascalToSnake } from '@/lib/string-utils';
 import FetchError from '@/components/FetchError.vue';
 import Loader from '@/components/Loader.vue';
 
-
 interface QuestionWrapperProps {
     questionId: Quizoot.Question['id'];
     questionNumber: number;
@@ -42,8 +41,8 @@ const props = defineProps<QuestionWrapperProps>();
 const {
     data: question,
     error: errorOccurred,
-    isFetching: isFetchingQuestion
-} = await useFetch<Question>(`/api/questions/${props.questionId}`)
+    isFetching: isFetchingQuestion,
+} = await useFetch<Question>(`/api/questions/${props.questionId}`);
 
 const QuestionSpec: ComputedRef<Component> = computed(() => {
     if (question.value?.kind in components) {
@@ -83,13 +82,9 @@ function toggleHint() {
         </div>
 
         <div class="question-props">
-            <span id="difficulty">{{
-                question.difficulty.toUpperCase()
-            }}</span>
+            <span id="difficulty">{{ question.difficulty.toUpperCase() }}</span>
             <span>&#8226; </span>
-            <span id="grading"
-                >{{ question.grading.point_value }} pts</span
-            >
+            <span id="grading">{{ question.grading.point_value }} pts</span>
         </div>
 
         <div class="question">

--- a/frontend/src/components/Question.vue
+++ b/frontend/src/components/Question.vue
@@ -9,12 +9,12 @@ import FetchError from '@/components/FetchError.vue';
 import Loader from '@/components/Loader.vue';
 
 interface QuestionWrapperProps {
-    questionId: Quizoot.Question['id'];
-    questionNumber: number;
-    questionsCount: number;
+    id: Quizoot.Question['id'];
+    rank: number;
+    totalQuestions: number;
 }
 
-type Component = Promise<any>;
+type Component = Promise<object>;
 type ComponentsMap = Record<Quizoot.QuestionKind, Component>;
 
 function getComponents() {
@@ -42,7 +42,7 @@ const {
     data: question,
     error: errorOccurred,
     isFetching: isFetchingQuestion,
-} = await useFetch<Question>(`/api/questions/${props.questionId}`);
+} = await useFetch<Question>(`/api/questions/${props.id}`);
 
 const QuestionSpec: ComputedRef<Component> = computed(() => {
     if (question.value?.kind in components) {
@@ -76,8 +76,8 @@ function toggleHint() {
     <div v-else class="question-wrapper">
         <div class="question-number">
             <h1>
-                Question {{ props.questionNumber }}
-                <span> / {{ props.questionsCount }}</span>
+                Question {{ props.rank }}
+                <span> / {{ props.totalQuestions }}</span>
             </h1>
         </div>
 

--- a/frontend/src/components/Question.vue
+++ b/frontend/src/components/Question.vue
@@ -2,29 +2,25 @@
 import { computed, defineAsyncComponent, ref } from 'vue';
 import type { ComputedRef, Ref } from 'vue';
 import type { Quizoot } from '@interfaces/quizoot';
-import NavigationButton from '@/components/NavigationButton.vue';
+import type { Question } from '@interfaces/quizoot.indexed';
+import { useFetch } from '@/lib/hooks';
 import { pascalToSnake } from '@/lib/string-utils';
+import FetchError from '@/components/FetchError.vue';
+import Loader from '@/components/Loader.vue';
 
-interface QuestionsFlow {
-    questionNumber: number;
-    isFirstQuestion: boolean;
-    isLastQuestion: boolean;
-}
 
 interface QuestionWrapperProps {
-    question: Quizoot.Question;
-    questionsFlow: QuestionsFlow;
+    questionId: Quizoot.Question['id'];
+    questionNumber: number;
     questionsCount: number;
-    goToPreviousQuestion: () => void;
-    goToNextQuestion: () => void;
 }
 
-type Components = Promise<any>;
-type ComponentsMap = Record<Quizoot.QuestionKind, Components>;
+type Component = Promise<any>;
+type ComponentsMap = Record<Quizoot.QuestionKind, Component>;
 
 function getComponents() {
     const files = import.meta.glob('@/components/questions/*.vue');
-    const components: Record<string, Components> = {};
+    const components: Record<string, Component> = {};
 
     for (const filepath in files) {
         const filename = filepath.match(/.*\/(.+)\.vue$/)?.[1];
@@ -43,11 +39,17 @@ const components = getComponents();
 
 const props = defineProps<QuestionWrapperProps>();
 
-const QuestionSpec: ComputedRef = computed(() => {
-    if (props.question.kind in components) {
-        return components[props.question.kind];
+const {
+    data: question,
+    error: errorOccurred,
+    isFetching: isFetchingQuestion
+} = await useFetch<Question>(`/api/questions/${props.questionId}`)
+
+const QuestionSpec: ComputedRef<Component> = computed(() => {
+    if (question.value?.kind in components) {
+        return components[question.value?.kind as Quizoot.QuestionKind];
     } else {
-        throw Error(`Unknown QuestionKind "${props.question.kind}"`);
+        throw Error(`Unknown QuestionKind "${question.value?.kind}"`);
     }
 });
 
@@ -58,7 +60,7 @@ const DIFFICULTY_COLOR_MAP: Record<Quizoot.Difficulty, string> = {
 };
 
 const difficultyColor: ComputedRef = computed(
-    () => DIFFICULTY_COLOR_MAP[props.question.difficulty]
+    () => DIFFICULTY_COLOR_MAP[question.value?.difficulty as Quizoot.Difficulty]
 );
 
 const displayHint: Ref<boolean> = ref(false);
@@ -66,51 +68,39 @@ const displayHint: Ref<boolean> = ref(false);
 function toggleHint() {
     displayHint.value = !displayHint.value;
 }
-
-function goTo(s: 'next' | 'previous') {
-    displayHint.value = false;
-    switch (s) {
-        case 'next':
-            props.goToNextQuestion();
-            break;
-        case 'previous':
-            props.goToPreviousQuestion();
-            break;
-        default:
-            break;
-    }
-}
 </script>
 
 <template>
     <div class="progress-bar"></div>
-    <div class="question-wrapper">
+    <FetchError v-if="errorOccurred" />
+    <Loader v-else-if="isFetchingQuestion" />
+    <div v-else class="question-wrapper">
         <div class="question-number">
             <h1>
-                Question {{ props.questionsFlow.questionNumber }}
+                Question {{ props.questionNumber }}
                 <span> / {{ props.questionsCount }}</span>
             </h1>
         </div>
 
         <div class="question-props">
             <span id="difficulty">{{
-                props.question.difficulty.toUpperCase()
+                question.difficulty.toUpperCase()
             }}</span>
             <span>&#8226; </span>
             <span id="grading"
-                >{{ props.question.grading.point_value }} pts</span
+                >{{ question.grading.point_value }} pts</span
             >
         </div>
 
         <div class="question">
-            <p>{{ props.question.question }}</p>
+            <p>{{ question.question }}</p>
         </div>
 
         <keep-alive>
-            <QuestionSpec :spec="props.question.spec" />
+            <QuestionSpec :spec="question.spec" />
         </keep-alive>
 
-        <div v-if="props.question.hint" class="question-hint">
+        <div v-if="question.hint" class="question-hint">
             <div @click="toggleHint" class="hint-toggler">
                 <font-awesome-icon
                     v-if="displayHint"
@@ -125,30 +115,8 @@ function goTo(s: 'next' | 'previous') {
                 <p>Hint</p>
             </div>
             <div class="hint" :class="{ display: displayHint }">
-                {{ props.question.hint }}
+                {{ question.hint }}
             </div>
-        </div>
-
-        <div class="navigation-button-group">
-            <navigation-button
-                v-if="!props.questionsFlow.isFirstQuestion"
-                @click="goTo('previous')"
-                backgroundColor="var(--palette-mobster)"
-                chevronLeft
-                class="previous-button button"
-            >
-                Previous
-            </navigation-button>
-            <div class="button-separator"></div>
-            <navigation-button
-                v-if="!props.questionsFlow.isLastQuestion"
-                @click="goTo('next')"
-                backgroundColor="var(--main-purple-lightened)"
-                chevronRight
-                class="next-button button"
-            >
-                Next
-            </navigation-button>
         </div>
     </div>
 </template>
@@ -234,29 +202,12 @@ function goTo(s: 'next' | 'previous') {
     text-align: left;
     color: black;
     padding: 10px;
-    /* margin-bottom: 50px; */
     border: 2px solid var(--main-purple-lightened);
     border-radius: 4px;
 }
 
 .display {
     display: block;
-}
-
-.navigation-button-group {
-    display: flex;
-    width: 80%;
-    align-items: center;
-    justify-content: space-between;
-}
-
-.button-separator {
-    width: 1px;
-    height: 100%;
-}
-
-.navigation-button-group .button {
-    min-width: 150px;
 }
 
 @media only screen and (max-width: 600px) {
@@ -267,10 +218,6 @@ function goTo(s: 'next' | 'previous') {
     .question-hint {
         flex-direction: column;
         width: 90%;
-    }
-
-    .navigation-button-group {
-        width: 100%;
     }
 }
 </style>

--- a/frontend/src/components/QuestionsNavigation.vue
+++ b/frontend/src/components/QuestionsNavigation.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+import NavigationButton from '@/components/NavigationButton.vue';
+
+interface QuestionsNavigationProps {
+    isFirstQuestion: boolean;
+    isLastQuestion: boolean;
+    goToPreviousQuestion: () => void;
+    goToNextQuestion: () => void;
+}
+
+const props = defineProps<QuestionsNavigationProps>();
+
+function goTo(s: 'next' | 'previous') {
+    switch (s) {
+        case 'next':
+            props.goToNextQuestion();
+            break;
+        case 'previous':
+            props.goToPreviousQuestion();
+            break;
+        default:
+            break;
+    }
+}
+</script>
+
+<template>
+    <div class="navigation-button-group">
+        <navigation-button
+            v-if="!props.isFirstQuestion"
+            @click="goTo('previous')"
+            backgroundColor="var(--palette-mobster)"
+            chevronLeft
+            class="previous-button button"
+        >
+            Previous
+        </navigation-button>
+        <div class="button-separator"></div>
+        <navigation-button
+            v-if="!props.isLastQuestion"
+            @click="goTo('next')"
+            backgroundColor="var(--main-purple-lightened)"
+            chevronRight
+            class="next-button button"
+        >
+            Next
+        </navigation-button>
+    </div>
+</template>
+
+<style scoped>
+.navigation-button-group {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 80%;
+    margin-top: 1em;
+}
+
+.button-separator {
+    width: 1px;
+    height: 100%;
+}
+
+.navigation-button-group .button {
+    min-width: 150px;
+}
+
+@media only screen and (max-width: 600px) {
+    .navigation-button-group {
+        width: 100%;
+    }
+}
+</style>

--- a/frontend/src/lib/hooks.ts
+++ b/frontend/src/lib/hooks.ts
@@ -1,4 +1,4 @@
-import { ref } from 'vue';
+import { ref, watch } from 'vue';
 import type { Ref } from 'vue';
 import type { AxiosRequestConfig } from 'axios';
 
@@ -37,6 +37,8 @@ export async function useFetch<TData extends ApiResponse>(
     }
 
     await fetchData();
+
+    watch(() => url, fetchData);
 
     return state;
 }

--- a/frontend/src/views/Quiz.vue
+++ b/frontend/src/views/Quiz.vue
@@ -1,93 +1,59 @@
 <script setup lang="ts">
-import { ref, computed, onBeforeMount } from 'vue';
+import { ref, computed } from 'vue';
 import type { Ref, ComputedRef } from 'vue';
 import { useRoute } from 'vue-router';
 import type { Quizoot } from '@interfaces/quizoot';
-import type {
-    Quiz,
-    Question as QuizQuestion,
-} from '@interfaces/quizoot.indexed';
-import { useStore } from '@/store/store';
-import { MutationTypes } from '@/store/types';
+import type { Quiz } from '@interfaces/quizoot.indexed';
 import { log } from '@/lib';
 import { useFetch } from '@/lib/hooks';
 import QuizPreview from '@/components/QuizPreview.vue';
 import Question from '@/components/Question.vue';
+import QuestionsNavigation from '@/components/QuestionsNavigation.vue';
+import FetchError from '@/components/FetchError.vue';
+import Loader from '@/components/Loader.vue';
 
 const route = useRoute();
-const store = useStore();
 
-const quizQuestions: Ref<QuizQuestion[]> = ref([]);
+const quiz: Ref<Quiz | null> = ref(null);
 const errorOccurred: Ref<boolean> = ref(false);
-const isFetchingQuiz: ComputedRef<boolean> = computed(
-    () => store.state.currentQuiz === null
-);
+const isFetchingQuiz: Ref<boolean> = ref(true);
 
-onBeforeMount(() => {
-    useFetch<Quiz>(`/api/quizzes/${route.params.id}`)
-        .then((response) => {
-            if (response.error.value) {
-                errorOccurred.value = true;
-                log(response.error.value);
-            } else {
-                store.commit(
-                    MutationTypes.UPDATE_CURRENT_QUIZ,
-                    response.data.value
-                );
-
-                for (const question of response.data.value?.questions || []) {
-                    useFetch<QuizQuestion>(
-                        `/api/questions/${question.question_id}`
-                    )
-                        .then((response) => {
-                            if (response.error.value) {
-                                log(response.error.value);
-                            }
-                            if (response.data.value) {
-                                quizQuestions.value.push(
-                                    response.data.value as QuizQuestion
-                                );
-                            }
-                        })
-                        .catch((error) => {
-                            log(error);
-                        });
-                }
-            }
-        })
-        .catch((error) => {
+useFetch<Quiz>(`/api/quizzes/${route.params.id}`)
+    .then((response) => {
+        if (response.error.value) {
             errorOccurred.value = true;
-            log(error);
-        });
+            log(response.error.value);
+        } else {
+            quiz.value = response.data.value;
+        }
+        isFetchingQuiz.value = false;
+    })
+    .catch((error) => {
+        errorOccurred.value = true;
+        isFetchingQuiz.value = false;
+        log(error);
+    });
+
+
+const questionItems: ComputedRef<
+    Record<Quizoot.QuestionItem['question_id'], Quizoot.QuestionItem>
+> = computed(() => {
+    const questionItems: Record<
+        Quizoot.QuestionItem['question_id'], Quizoot.QuestionItem
+    > = {};
+    for (const questionItem of quiz.value?.questions) {
+        questionItems[questionItem.question_id] = questionItem;
+    }
+    return questionItems;
 });
 
-const quiz: ComputedRef<Quiz | null> = computed(() => store.state.currentQuiz);
-
-const currentQuestion: Ref<QuizQuestion | null> = ref(null);
 const currentQuestionItem: Ref<Quizoot.QuestionItem | null> = ref(null);
 const currentQuestionNumber: Ref<number> = ref(0);
 
-const questionsFlow: ComputedRef = computed(() => {
-    return {
-        questionNumber:
-            currentQuestionItem.value == null ? 0 : currentQuestionNumber.value,
-        isFirstQuestion: currentQuestionItem.value?.prev_question_id == null,
-        isLastQuestion: currentQuestionItem.value?.next_question_id == null,
-    };
-});
-
-function getQuizQuestionOfId(id: Quizoot.Question['id']) {
-    for (const question of quizQuestions.value) {
-        if (question.id === id) {
-            return question;
-        }
-    }
-    return null;
-}
 
 function getFirstQuestionItem() {
     for (const question of quiz.value?.questions || []) {
-        if (question.prev_question_id == null) {
+        if (question.prev_question_id === null) {
             return question;
         }
     }
@@ -96,83 +62,41 @@ function getFirstQuestionItem() {
 
 function startQuiz() {
     currentQuestionItem.value = getFirstQuestionItem();
-    if (currentQuestionItem.value) {
-        currentQuestion.value = getQuizQuestionOfId(
-            currentQuestionItem.value.question_id
-        );
-    }
     currentQuestionNumber.value = 1;
 }
 
 function quitQuiz() {
     currentQuestionItem.value = null;
-    currentQuestion.value = null;
+    currentQuestionNumber.value = 0;
 }
 
 function goToNextQuestion() {
     if (currentQuestionItem.value?.next_question_id) {
-        for (const question of quiz.value?.questions || []) {
-            if (
-                question.question_id ===
-                    currentQuestionItem.value?.next_question_id ||
-                []
-            ) {
-                currentQuestionItem.value = question;
-                currentQuestion.value = getQuizQuestionOfId(
-                    question.question_id
-                );
-                currentQuestionNumber.value++;
-                return;
-            }
-        }
+        currentQuestionItem.value = questionItems.value[
+            currentQuestionItem.value.next_question_id
+        ];
+        currentQuestionNumber.value++;
     }
-    console.log(currentQuestion.value);
 }
 
 function goToPreviousQuestion() {
     if (currentQuestionItem.value?.prev_question_id) {
-        for (const question of quiz.value?.questions || []) {
-            if (
-                question.question_id ===
-                    currentQuestionItem.value?.prev_question_id ||
-                []
-            ) {
-                currentQuestionItem.value = question;
-                currentQuestion.value = getQuizQuestionOfId(
-                    question.question_id
-                );
-                currentQuestionNumber.value--;
-                return;
-            }
-        }
+        currentQuestionItem.value = questionItems.value[
+            currentQuestionItem.value.prev_question_id
+        ];
+        currentQuestionNumber.value--;
     }
 }
 </script>
 
 <template>
-    <div v-if="errorOccurred" class="quiz-fetch-error">
-        <font-awesome-icon
-            icon="fa-solid fa-triangle-exclamation"
-            size="2xl"
-            color="var(--main-purple-lightened)"
-            class="warning-icon"
-        />
-        <br />
-        <p>Sorry, something went wrong...</p>
-    </div>
-    <div v-else-if="isFetchingQuiz">
-        <font-awesome-icon
-            icon="fa-solid fa-spinner"
-            size="2xl"
-            color="var(--main-purple-lightened)"
-            class="spinner"
-        />
-        <p>Loading...</p>
-    </div>
-    <div v-else class="quiz-container">
+    <FetchError v-if="errorOccurred" />
+    <Loader v-else-if="isFetchingQuiz" />
+    <div v-else
+         class="quiz-container">
         <h1 class="quiz-title">
             <span
-                v-if="currentQuestion != null"
+                v-if="currentQuestionItem != null"
                 class="back-to-quiz-preview-icon"
             >
                 <font-awesome-icon
@@ -184,54 +108,38 @@ function goToPreviousQuestion() {
         </h1>
         <br />
         <QuizPreview
-            v-if="currentQuestion == null"
-            :questionsCount="quizQuestions.length"
+            v-if="currentQuestionItem === null"
+            :questionsCount="quiz.questions.length"
             :description="quiz.description"
             :authors="quiz.authors"
             :onStart="startQuiz"
         />
-        <question
-            v-else
-            :question="currentQuestion"
-            :questionsCount="quizQuestions.length"
-            :questionsFlow="questionsFlow"
-            :goToNextQuestion="goToNextQuestion"
-            :goToPreviousQuestion="goToPreviousQuestion"
-        >
-        </question>
+        <Suspense>
+            <question
+                v-if="currentQuestionItem != null"
+                :questionId="currentQuestionItem.question_id"
+                :questionsCount="quiz.questions.length"
+                :questionNumber="currentQuestionNumber"
+                :key="currentQuestionItem.question_id"
+            >
+            </question>
+        </Suspense>
+        <QuestionsNavigation
+                v-if="currentQuestionItem != null"
+                :isFirstQuestion="currentQuestionNumber === 1"
+                :isLastQuestion="currentQuestionNumber === quiz.questions.length"
+                :goToNextQuestion="goToNextQuestion"
+                :goToPreviousQuestion="goToPreviousQuestion" />
     </div>
 </template>
 
 <style scoped>
-.quiz-fetch-error .warning-icon {
-    font-size: 4em;
-}
-
-.quiz-fetch-error p {
-    font-style: italic;
-}
-
 .quiz-container {
     display: flex;
     flex-direction: column;
-    justify-content: center;
     align-items: center;
     width: 80%;
     margin: 0;
-}
-
-.spinner {
-    animation: spin 1.65s linear infinite;
-}
-
-@keyframes spin {
-    from {
-        transform: rotate(0deg);
-    }
-
-    to {
-        transform: rotate(360deg);
-    }
 }
 
 .quiz-container .quiz-title {

--- a/frontend/src/views/Quiz.vue
+++ b/frontend/src/views/Quiz.vue
@@ -48,7 +48,7 @@ const questionItems: ComputedRef<
 });
 
 const currentQuestionItem: Ref<Quizoot.QuestionItem | null> = ref(null);
-const currentQuestionNumber: Ref<number> = ref(0);
+const currentQuestionRank: Ref<number> = ref(0);
 
 function getFirstQuestionItem() {
     for (const question of quiz.value?.questions || []) {
@@ -61,19 +61,19 @@ function getFirstQuestionItem() {
 
 function startQuiz() {
     currentQuestionItem.value = getFirstQuestionItem();
-    currentQuestionNumber.value = 1;
+    currentQuestionRank.value = 1;
 }
 
 function quitQuiz() {
     currentQuestionItem.value = null;
-    currentQuestionNumber.value = 0;
+    currentQuestionRank.value = 0;
 }
 
 function goToNextQuestion() {
     if (currentQuestionItem.value?.next_question_id) {
         currentQuestionItem.value =
             questionItems.value[currentQuestionItem.value.next_question_id];
-        currentQuestionNumber.value++;
+        currentQuestionRank.value++;
     }
 }
 
@@ -81,7 +81,7 @@ function goToPreviousQuestion() {
     if (currentQuestionItem.value?.prev_question_id) {
         currentQuestionItem.value =
             questionItems.value[currentQuestionItem.value.prev_question_id];
-        currentQuestionNumber.value--;
+        currentQuestionRank.value--;
     }
 }
 </script>
@@ -113,17 +113,17 @@ function goToPreviousQuestion() {
         <Suspense>
             <question
                 v-if="currentQuestionItem != null"
-                :questionId="currentQuestionItem.question_id"
-                :questionsCount="quiz.questions.length"
-                :questionNumber="currentQuestionNumber"
+                :id="currentQuestionItem.question_id"
+                :totalQuestions="quiz.questions.length"
+                :rank="currentQuestionRank"
                 :key="currentQuestionItem.question_id"
             >
             </question>
         </Suspense>
         <QuestionsNavigation
             v-if="currentQuestionItem != null"
-            :isFirstQuestion="currentQuestionNumber === 1"
-            :isLastQuestion="currentQuestionNumber === quiz.questions.length"
+            :isFirstQuestion="currentQuestionRank === 1"
+            :isLastQuestion="currentQuestionRank === quiz.questions.length"
             :goToNextQuestion="goToNextQuestion"
             :goToPreviousQuestion="goToPreviousQuestion"
         />

--- a/frontend/src/views/Quiz.vue
+++ b/frontend/src/views/Quiz.vue
@@ -34,14 +34,14 @@ useFetch<Quiz>(`/api/quizzes/${route.params.id}`)
         log(error);
     });
 
-
 const questionItems: ComputedRef<
     Record<Quizoot.QuestionItem['question_id'], Quizoot.QuestionItem>
 > = computed(() => {
     const questionItems: Record<
-        Quizoot.QuestionItem['question_id'], Quizoot.QuestionItem
+        Quizoot.QuestionItem['question_id'],
+        Quizoot.QuestionItem
     > = {};
-    for (const questionItem of quiz.value?.questions) {
+    for (const questionItem of quiz.value?.questions || []) {
         questionItems[questionItem.question_id] = questionItem;
     }
     return questionItems;
@@ -49,7 +49,6 @@ const questionItems: ComputedRef<
 
 const currentQuestionItem: Ref<Quizoot.QuestionItem | null> = ref(null);
 const currentQuestionNumber: Ref<number> = ref(0);
-
 
 function getFirstQuestionItem() {
     for (const question of quiz.value?.questions || []) {
@@ -72,18 +71,16 @@ function quitQuiz() {
 
 function goToNextQuestion() {
     if (currentQuestionItem.value?.next_question_id) {
-        currentQuestionItem.value = questionItems.value[
-            currentQuestionItem.value.next_question_id
-        ];
+        currentQuestionItem.value =
+            questionItems.value[currentQuestionItem.value.next_question_id];
         currentQuestionNumber.value++;
     }
 }
 
 function goToPreviousQuestion() {
     if (currentQuestionItem.value?.prev_question_id) {
-        currentQuestionItem.value = questionItems.value[
-            currentQuestionItem.value.prev_question_id
-        ];
+        currentQuestionItem.value =
+            questionItems.value[currentQuestionItem.value.prev_question_id];
         currentQuestionNumber.value--;
     }
 }
@@ -92,8 +89,7 @@ function goToPreviousQuestion() {
 <template>
     <FetchError v-if="errorOccurred" />
     <Loader v-else-if="isFetchingQuiz" />
-    <div v-else
-         class="quiz-container">
+    <div v-else class="quiz-container">
         <h1 class="quiz-title">
             <span
                 v-if="currentQuestionItem != null"
@@ -125,11 +121,12 @@ function goToPreviousQuestion() {
             </question>
         </Suspense>
         <QuestionsNavigation
-                v-if="currentQuestionItem != null"
-                :isFirstQuestion="currentQuestionNumber === 1"
-                :isLastQuestion="currentQuestionNumber === quiz.questions.length"
-                :goToNextQuestion="goToNextQuestion"
-                :goToPreviousQuestion="goToPreviousQuestion" />
+            v-if="currentQuestionItem != null"
+            :isFirstQuestion="currentQuestionNumber === 1"
+            :isLastQuestion="currentQuestionNumber === quiz.questions.length"
+            :goToNextQuestion="goToNextQuestion"
+            :goToPreviousQuestion="goToPreviousQuestion"
+        />
     </div>
 </template>
 

--- a/frontend/src/views/Quiz.vue
+++ b/frontend/src/views/Quiz.vue
@@ -185,8 +185,15 @@ function goToPreviousQuestion() {
         margin-inline: 5%;
     }
 
+    .quiz-container .quiz-title {
+        position: relative;
+        text-align: center;
+    }
+
     .quiz-container .quiz-title .back-to-quiz-preview-icon {
-        width: 1.25em;
+        position: absolute;
+        left: -1em;
+        width: 1em;
     }
 }
 </style>


### PR DESCRIPTION
## What's new

1. I added:
    *  a loader (see `components/Loader.vue`), displayed while resources are being fetched (quizzes and questions)

    * a message when an error occurs while fetching (see `components/FetchError.vue`)

2. I added a dedicated component for navigation buttons, as discussed in #69 

3. The questions are now fetched in the `Question` component using the question `id` passed as a `prop`, using the syntax:
```ts
const {question, error, isFetching} = await useFetch<Question>('...');
```

> As as mentionned in #69 , the answers are no more "kept alive".
>

## Notes

The list of all quizzes in `Home` and the selected quiz in `Quiz` views, are still using the syntax:
```ts
useFetch<Q>('...')
    .then()
    .catch()
```
I think this should be kept as it is, because using the same way as `Question` need for the views to be wrapped in a `Suspense` component, which doesn't seems doable. <br><br>
What do you think ?