### PR TITLE
Better typing + schemas regeneration

### DIFF
--- a/interfaces/.prettierrc.yaml
+++ b/interfaces/.prettierrc.yaml
@@ -1,0 +1,3 @@
+singleQuote: true
+proseWrap: always
+useTabs: true

--- a/interfaces/index.ts
+++ b/interfaces/index.ts
@@ -3,34 +3,68 @@ import * as tjs from 'typescript-json-schema';
 
 import path from 'path';
 
-const SCHEMAS_DIR = path.join(__dirname, "./schemas");
+const SCHEMAS_DIR = path.join(__dirname, './schemas');
 const SOURCE_FILE_PATH = path.join(__dirname, './quizoot.ts');
 
 // Arguments to be passed to schema generator
 const SETTINGS: tjs.PartialArgs = {
-    required: true,
+	required: true,
 };
 
-const SCHEMAS_TO_GENERATE = [
-    {
-        type: 'Quizoot.Question',
-        name: 'question'
-    },
-    {
-        type: 'Quizoot.Quiz',
-        name: 'quiz'
-    }
-];
+const program = tjs.getProgramFromFiles([path.resolve(SOURCE_FILE_PATH)]);
 
+async function main() {
+	const schema = generateSchema('QuestionKind');
+	saveSchema('question_kind', schema);
+	const questionKinds = ((schema?.enum as string[]) ?? []).map((s) =>
+		s.toLowerCase()
+	);
 
-SCHEMAS_TO_GENERATE.forEach((schema) => {
-    const program = tjs.getProgramFromFiles([path.resolve(SOURCE_FILE_PATH)]);
-    const definition = tjs.generateSchema(program, schema.type, SETTINGS);
-    
-    try {
-        const filepath = path.join(SCHEMAS_DIR, `./${schema.name}.json`)
-        fs.writeFileSync(filepath, JSON.stringify(definition, null, 2) + '\n');
-    } catch (err) {
-        console.error(err);
-    }
-});
+	// Generate appropriate schema for each kind of question
+	for (const kind of questionKinds) {
+		try {
+			const schema = generateSchema(snakeToPascal(kind));
+			saveSchema(kind, schema);
+		} catch (err) {
+			console.error('Could not generate schema', kind);
+		}
+	}
+
+	// Generate question schema (union of all questions)
+	saveSchema('question', generateSchema('Question'));
+
+	// Generate quiz schema
+	saveSchema('quiz', generateSchema('Quiz'));
+}
+
+function generateSchema(typeName: string) {
+	console.log(`[INFO] Generating "Quizoot.${typeName}" schema`);
+	return tjs.generateSchema(program, `Quizoot.${typeName}`, SETTINGS);
+}
+
+async function saveSchema(name: string, schema: tjs.Definition | null) {
+	return fs.writeFile(
+		path.join(SCHEMAS_DIR, `${name}.json`),
+		JSON.stringify(schema, null, 4),
+		(err) => {
+			if (err) {
+				console.error(`unable to save ${name} schema.`);
+			}
+		}
+	);
+}
+
+function snakeToPascal(s: string) {
+	return s.toLowerCase().split('_').map(capitalize).join('');
+}
+
+function capitalize(s: string) {
+	return s[0].toUpperCase() + s.slice(1);
+}
+
+void main()
+	.then(() => console.log('[INFO] All schemas generated !'))
+	.catch((err) => {
+		console.error('[ERROR]', err);
+		process.exit(1);
+	});

--- a/interfaces/package.json
+++ b/interfaces/package.json
@@ -8,6 +8,7 @@
     "devDependencies": {
         "@swc/core": "^1.3.20",
         "@types/node": "^18.11.9",
+        "prettier": "^2.8.4",
         "tsconfig-paths": "^4.1.0",
         "typescript-json-schema": "^0.55.0"
     },

--- a/interfaces/quizoot.ts
+++ b/interfaces/quizoot.ts
@@ -1,276 +1,305 @@
 export declare namespace Quizoot {
-    /**
-     * Question object used to create a quiz. A Quiz is a set of questions.
-     *
-     * @version 0.1.0
-     */
-    export interface Question {
-        /**
-         * Id of the question
-         * 
-         * @pattern [a-z0-9]{24}
-         */
-        id: string;
-        /**
-         * The actual question as a human-readable string.
-         */
-        question: string;
-        /** 
-         * The question kind. Please refer to {@link QuestionKind}.
-         */
-        kind: QuestionKind;
-        /** 
-         * Spec of the question. It specifies what the attributes of the question are. Attributes depends on {@link QuestionKind}.
-         * 
-         * See {@link QuestionSpec} for more information about the spec attributes for each question kind.
-         */
-        spec: QuestionSpec;
-        /** 
-         * The grading object specifies how to grade for the current question. See {@link Grading}.
-        */
-        grading: Grading;
-        /** 
-         * Rate how difficult the question is. See {@link Difficulty}.
-         */
-        difficulty: Difficulty;
-        /** 
-         * List of optional tags associated with the question.
-         */
-        tags?: string[];
-        /** 
-         * Hint given to help answering the question 
-         */
-        hint?: string;
-    }
+	/**
+	 * Different kind of question we might have.
+	 */
+	export type QuestionKind =
+		| 'SINGLE_CHOICE_QUESTION'
+		| 'MULTIPLE_CHOICES_QUESTION'
+		| 'TEXT_QUESTION'
+		| 'UPLOAD_QUESTION'
+		| 'CODE_QUESTION';
 
-    /** 
-     * Different kind of question we might have.
-     */
-    type QuestionKind = "CHOICE_QUESTION" | "TEXT_QUESTION" | "UPLOAD_QUESTION" | "CODE_QUESTION";
+	/**
+	 * Question object used to create a quiz. A Quiz is a set of questions.
+	 *
+	 * @version 0.1.0
+	 */
+	export type Question =
+		| SingleChoiceQuestion
+		| MultipleChoicesQuestion
+		| TextQuestion
+		| UploadQuestion
+		| CodeQuestion;
 
-    interface Grading {
-        /**
-         * Specifies how much a correct answer count for in the total score.
-         */
-        point_value: number;
-        /**
-         * Feedback given after answering the question.
-         */
-        feedback: Feedback;
-    }
+	export type SingleChoiceQuestion = QuestionBuilder<'SINGLE_CHOICE_QUESTION'>;
 
-    interface Feedback {
-        /** 
-         * General feedback/explanation displayed whether the answer is wrong or correct. 
-         */
-        explanation: string;
-        /**
-         * Feedback when answer is wrong.
-         */
-        when_wrong?: string;
-        /**
-         * Feedback when answer is right.
-         */
-        when_right?: string;
-    }
+	export type MultipleChoicesQuestion =
+		QuestionBuilder<'MULTIPLE_CHOICES_QUESTION'>;
 
-    /** 
-     * Question difficulty: easy, medium or hard.
-     */
-    type Difficulty = "EASY" | "MEDIUM" | "HARD";
+	export type TextQuestion = QuestionBuilder<'TEXT_QUESTION'>;
 
-    /**
-     * Question spec. It depends on the question kind.
-     */
-    type QuestionSpec = ChoiceQuestion | TextQuestion | UploadQuestion | CodeQuestion;
+	export type UploadQuestion = QuestionBuilder<'UPLOAD_QUESTION'>;
 
-    /**
-     * Choice question : can either be a [Single Choice Question]{@link SingleChoiceQuestion} or a [Multiple Choices Question]{@link MultipleChoicesQuestion}.
-     */
-    type ChoiceQuestion = SingleChoiceQuestion | MultipleChoicesQuestion;
+	export type CodeQuestion = QuestionBuilder<'CODE_QUESTION'>;
 
-    interface SingleChoiceQuestion {
-        /**
-         * Question options. See {@link QuestionOption}.
-         */
-        options: QuestionOption[]
-        /**
-         * Id of the correct answer to the question.
-         */
-        answer_id: OptionId;
-    }
+	interface QuestionBuilder<T extends QuestionKind> {
+		/**
+		 * Id of the question
+		 *
+		 * @pattern [a-z0-9]{24}
+		 */
+		id: string;
+		/**
+		 * The actual question as a human-readable string.
+		 */
+		question: string;
+		/**
+		 * The question kind. Please refer to {@link QuestionKind}.
+		 */
+		kind: T;
+		/**
+		 * Spec of the question. It specifies what the attributes of the question are. Attributes depends on {@link QuestionKind}.
+		 *
+		 * See {@link QuestionSpec} for more information about the spec attributes for each question kind.
+		 */
+		spec: QuestionSpec<T>;
+		/**
+		 * The grading object specifies how to grade for the current question. See {@link Grading}.
+		 */
+		grading: Grading;
+		/**
+		 * Rate how difficult the question is. See {@link Difficulty}.
+		 */
+		difficulty: Difficulty;
+		/**
+		 * List of optional tags associated with the question.
+		 */
+		tags?: string[];
+		/**
+		 * Hint given to help answering the question
+		 */
+		hint?: string;
+	}
 
-    interface MultipleChoicesQuestion {
-        /**
-         * Question options. See {@link QuestionOption}.
-         */
-        options: QuestionOption[]
-        /**
-         * Id of the correct answers to the question.
-         */
-        answers_id: OptionId[];
-    }
+	interface Grading {
+		/**
+		 * Specifies how much a correct answer count for in the total score.
+		 */
+		point_value: number;
+		/**
+		 * Feedback given after answering the question.
+		 */
+		feedback: Feedback;
+	}
 
-    interface QuestionOption {
-        /**
-         * Id of the option.
-         */
-        id: OptionId;
-        /**
-         * The actual display of the option as a human-readable string.
-         */
-        display: string;
-    }
+	interface Feedback {
+		/**
+		 * General feedback/explanation displayed whether the answer is wrong or correct.
+		 */
+		explanation: string;
+		/**
+		 * Feedback when answer is wrong.
+		 */
+		when_wrong?: string;
+		/**
+		 * Feedback when answer is right.
+		 */
+		when_right?: string;
+	}
 
-    type OptionId = string;
+	/**
+	 * Question difficulty: easy, medium or hard.
+	 */
+	type Difficulty = 'EASY' | 'MEDIUM' | 'HARD';
 
-    interface TextQuestion {
-        /**
-         * Placeholder to display in the html `textarea` or `input`
-         * 
-         * @examples ["Type your text here..."]
-         */
-        placeholder?: string;
-        /**
-         * List of keywords that the answers should contain. It is up to the developer to implement if the answer should contain ALL or ANY of the keywords.
-         * 
-         * @examples ["bytes", "octets"]
-         */
-        keywords?: string[];
-    }
+	type QuestionSpec<T extends QuestionKind> = T extends 'SINGLE_CHOICE_QUESTION'
+		? SingleChoiceQuestionSpec
+		: T extends 'MULTIPLE_CHOICES_QUESTION'
+		? MultipleChoicesQuestionSpec
+		: T extends 'TEXT_QUESTION'
+		? TextQuestionSpec
+		: T extends 'UPLOAD_QUESTION'
+		? UploadQuestionSpec
+		: T extends 'CODE_QUESTION'
+		? CodeQuestionSpec
+		: never;
 
-    interface UploadQuestion {
-        /**
-         * List of files to upload.
-         */
-        files: File[];
-        /**
-         * Maximum size of each files. Can be expressed in bytes, megabytes (MB), etc. See TODO for valid units.
-         * 
-         * @examples ["10MB"]
-         */
-        max_size: string;
-        /** 
-         * Maximum number of files to upload.
-         * 
-         * @default 1
-         * @minimum 1
-         */
-        max_files: number;
-    }
+	/**
+	 * Question spec. It depends on the question kind.
+	 */
 
-    interface File {
-        /**
-         * File type enum. Can be `.txt`, `.csv`, `.pdf`, etc. See {@link FileType}.
-         */
-        type: FileType;
-        /**
-         * Encoded `base64` string of the file's content.
-         */
-        content: string;
-    }
+	interface SingleChoiceQuestionSpec {
+		/**
+		 * Question options. See {@link QuestionOption}.
+		 */
+		options: QuestionOption[];
+		/**
+		 * Id of the correct answer to the question.
+		 */
+		answer_id: OptionId;
+	}
 
-    /**
-     * Enum of supported file extensions.
-     */
-    type FileType = ".txt" | ".csv" | ".pdf" | ".img" | ".jpg" | ".jpeg" | ".png";
+	interface MultipleChoicesQuestionSpec {
+		/**
+		 * Question options. See {@link QuestionOption}.
+		 */
+		options: QuestionOption[];
+		/**
+		 * Id of the correct answers to the question.
+		 */
+		answers_id: OptionId[];
+	}
 
-    interface CodeQuestion  {
-        /**
-         * Code content. This will be run using a `python3` runner and evaluated.
-         */
-        content: string;
-        /**
-         * Coding language. Only `python3` is supported.
-         */
-        language: "python3";
-        /**
-         * Expected output after running the code.
-         */
-        expected_output: string;
-    }
+	interface QuestionOption {
+		/**
+		 * Id of the option.
+		 */
+		id: OptionId;
+		/**
+		 * The actual display of the option as a human-readable string.
+		 */
+		display: string;
+	}
 
-    /**
-     * A Quiz object represents a set of questions.
-     *
-     * @version 0.1.0
-     */
-    export interface Quiz {
-        /**
-         * Id of the quiz.
-         *
-         * @pattern [a-z0-9]{24}
-         */
-        id: string;
-        /**
-         * The title (header) of the quiz.
-         *
-         * @minLength 1
-         * @maxLength 40
-         */
-        title: string;
-        /**
-         * A brief description of the quiz content, topic...
-         */
-        description: string;
-        /**
-         * Maximum score the user can get. Will be used to compute the final score: sum(question_i_score) / max_score.
-         *
-         * @default 0
-         * @minimum 0
-         */
-        max_score: number;
-        /**
-         * All the questions the quiz is made of.
-         */
-        questions: QuestionItem[]
-        /**
-         * List of optional authors or contributors of the quiz. See {@link Author}.
-         */
-        authors?: Author[];
-        /**
-         * List of optional tags associated with the quiz.
-         */
-        tags?: string[];
-    }
+	type OptionId = string;
 
-    interface QuestionItem {
-        /**
-         * Id of a question referenced in the quiz.
-         *
-         * @pattern [a-z0-9]{24}
-         */
-        question_id: string;
-        /**
-         * Id of the next question in the quiz chronology. Is null if it is the last question.
-         * @nullable
-         */
-        next_question_id: string | null;
-        /**
-         * Id of the previous question in the quiz chronology. Is null if it is the first question.
-         * @nullable
-         */
-        prev_question_id: string | null;
-    }
+	interface TextQuestionSpec {
+		/**
+		 * Placeholder to display in the html `textarea` or `input`
+		 *
+		 * @examples ["Type your text here..."]
+		 */
+		placeholder?: string;
+		/**
+		 * List of keywords that the answers should contain. It is up to the developer to implement if the answer should contain ALL or ANY of the keywords.
+		 *
+		 * @examples ["bytes", "octets"]
+		 */
+		keywords?: string[];
+	}
 
-    interface Author {
-        /**
-         * The quiz author's first name.
-         */
-        name: string;
-        /**
-         * The quiz author's last name. Is optional.
-         */
-        surname?: string;
-        /**
-         * A pseudo for the quiz author.
-         */
-        pseudo?: string;
-        /**
-         * The quiz author's email.
-         *
-         * @pattern ^[a-zA-Z]+[\w.\d-]*@[a-zA-Z]+\.[a-zA-Z]{1,3}$
-         */
-        email?: string;
-    }
+	interface UploadQuestionSpec {
+		/**
+		 * List of files to upload.
+		 */
+		files: File[];
+		/**
+		 * Maximum size of each files. Can be expressed in bytes, megabytes (MB), etc. See TODO for valid units.
+		 *
+		 * @examples ["10MB"]
+		 */
+		max_size: string;
+		/**
+		 * Maximum number of files to upload.
+		 *
+		 * @default 1
+		 * @minimum 1
+		 */
+		max_files: number;
+	}
+
+	interface File {
+		/**
+		 * File type enum. Can be `.txt`, `.csv`, `.pdf`, etc. See {@link FileType}.
+		 */
+		type: FileType;
+		/**
+		 * Encoded `base64` string of the file's content.
+		 */
+		content: string;
+	}
+
+	/**
+	 * Enum of supported file extensions.
+	 */
+	type FileType = '.txt' | '.csv' | '.pdf' | '.img' | '.jpg' | '.jpeg' | '.png';
+
+	interface CodeQuestionSpec {
+		/**
+		 * Code content. This will be run using a `python3` runner and evaluated.
+		 */
+		content: string;
+		/**
+		 * Coding language. Only `python3` is supported.
+		 */
+		language: 'python3';
+		/**
+		 * Expected output after running the code.
+		 */
+		expected_output: string;
+	}
+
+	/**
+	 * A Quiz object represents a set of questions.
+	 *
+	 * @version 0.1.0
+	 */
+	export interface Quiz {
+		/**
+		 * Id of the quiz.
+		 *
+		 * @pattern [a-z0-9]{24}
+		 */
+		id: string;
+		/**
+		 * The title (header) of the quiz.
+		 *
+		 * @minLength 1
+		 * @maxLength 40
+		 */
+		title: string;
+		/**
+		 * A brief description of the quiz content, topic...
+		 */
+		description: string;
+		/**
+		 * Maximum score the user can get. Will be used to compute the final score: sum(question_i_score) / max_score.
+		 *
+		 * @default 0
+		 * @minimum 0
+		 */
+		max_score: number;
+		/**
+		 * All the questions the quiz is made of.
+		 */
+		questions: QuestionItem[];
+		/**
+		 * List of optional authors or contributors of the quiz. See {@link Author}.
+		 */
+		authors?: Author[];
+		/**
+		 * List of optional tags associated with the quiz.
+		 */
+		tags?: string[];
+	}
+
+	interface QuestionItem {
+		/**
+		 * Id of a question referenced in the quiz.
+		 *
+		 * @pattern [a-z0-9]{24}
+		 */
+		question_id: string;
+		/**
+		 * Id of the next question in the quiz chronology. Is null if it is the last question.
+		 * @nullable
+		 */
+		next_question_id: string | null;
+		/**
+		 * Id of the previous question in the quiz chronology. Is null if it is the first question.
+		 * @nullable
+		 */
+		prev_question_id: string | null;
+	}
+
+	interface Author {
+		/**
+		 * The quiz author's first name.
+		 */
+		name: string;
+		/**
+		 * The quiz author's last name. Is optional.
+		 */
+		surname?: string;
+		/**
+		 * A pseudo for the quiz author.
+		 */
+		pseudo?: string;
+		/**
+		 * The quiz author's email.
+		 *
+		 * @pattern ^[a-zA-Z]+[\w.\d-]*@[a-zA-Z]+\.[a-zA-Z]{1,3}$
+		 */
+		email?: string;
+	}
 }

--- a/interfaces/schemas/code_question.json
+++ b/interfaces/schemas/code_question.json
@@ -1,0 +1,126 @@
+{
+    "type": "object",
+    "properties": {
+        "id": {
+            "description": "Id of the question",
+            "pattern": "[a-z0-9]{24}",
+            "type": "string"
+        },
+        "question": {
+            "description": "The actual question as a human-readable string.",
+            "type": "string"
+        },
+        "kind": {
+            "description": "The question kind. Please refer to {@link QuestionKind}.",
+            "type": "string",
+            "enum": [
+                "CODE_QUESTION"
+            ]
+        },
+        "spec": {
+            "$ref": "#/definitions/Quizoot.CodeQuestionSpec",
+            "description": "Spec of the question. It specifies what the attributes of the question are. Attributes depends on {@link QuestionKind}.\n\nSee {@link QuestionSpec} for more information about the spec attributes for each question kind."
+        },
+        "grading": {
+            "$ref": "#/definitions/Quizoot.Grading",
+            "description": "The grading object specifies how to grade for the current question. See {@link Grading}."
+        },
+        "difficulty": {
+            "$ref": "#/definitions/Quizoot.Difficulty",
+            "description": "Rate how difficult the question is. See {@link Difficulty}."
+        },
+        "tags": {
+            "description": "List of optional tags associated with the question.",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "hint": {
+            "description": "Hint given to help answering the question",
+            "type": "string"
+        }
+    },
+    "required": [
+        "difficulty",
+        "grading",
+        "id",
+        "kind",
+        "question",
+        "spec"
+    ],
+    "definitions": {
+        "Quizoot.CodeQuestionSpec": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "description": "Code content. This will be run using a `python3` runner and evaluated.",
+                    "type": "string"
+                },
+                "language": {
+                    "description": "Coding language. Only `python3` is supported.",
+                    "type": "string",
+                    "enum": [
+                        "python3"
+                    ]
+                },
+                "expected_output": {
+                    "description": "Expected output after running the code.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "content",
+                "expected_output",
+                "language"
+            ]
+        },
+        "Quizoot.Grading": {
+            "type": "object",
+            "properties": {
+                "point_value": {
+                    "description": "Specifies how much a correct answer count for in the total score.",
+                    "type": "number"
+                },
+                "feedback": {
+                    "$ref": "#/definitions/Quizoot.Feedback",
+                    "description": "Feedback given after answering the question."
+                }
+            },
+            "required": [
+                "feedback",
+                "point_value"
+            ]
+        },
+        "Quizoot.Feedback": {
+            "type": "object",
+            "properties": {
+                "explanation": {
+                    "description": "General feedback/explanation displayed whether the answer is wrong or correct.",
+                    "type": "string"
+                },
+                "when_wrong": {
+                    "description": "Feedback when answer is wrong.",
+                    "type": "string"
+                },
+                "when_right": {
+                    "description": "Feedback when answer is right.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "explanation"
+            ]
+        },
+        "Quizoot.Difficulty": {
+            "description": "Question difficulty: easy, medium or hard.",
+            "enum": [
+                "EASY",
+                "HARD",
+                "MEDIUM"
+            ],
+            "type": "string"
+        }
+    },
+    "$schema": "http://json-schema.org/draft-07/schema#"
+}

--- a/interfaces/schemas/multiple_choices_question.json
+++ b/interfaces/schemas/multiple_choices_question.json
@@ -1,0 +1,141 @@
+{
+    "type": "object",
+    "properties": {
+        "id": {
+            "description": "Id of the question",
+            "pattern": "[a-z0-9]{24}",
+            "type": "string"
+        },
+        "question": {
+            "description": "The actual question as a human-readable string.",
+            "type": "string"
+        },
+        "kind": {
+            "description": "The question kind. Please refer to {@link QuestionKind}.",
+            "type": "string",
+            "enum": [
+                "MULTIPLE_CHOICES_QUESTION"
+            ]
+        },
+        "spec": {
+            "$ref": "#/definitions/Quizoot.MultipleChoicesQuestionSpec",
+            "description": "Spec of the question. It specifies what the attributes of the question are. Attributes depends on {@link QuestionKind}.\n\nSee {@link QuestionSpec} for more information about the spec attributes for each question kind."
+        },
+        "grading": {
+            "$ref": "#/definitions/Quizoot.Grading",
+            "description": "The grading object specifies how to grade for the current question. See {@link Grading}."
+        },
+        "difficulty": {
+            "$ref": "#/definitions/Quizoot.Difficulty",
+            "description": "Rate how difficult the question is. See {@link Difficulty}."
+        },
+        "tags": {
+            "description": "List of optional tags associated with the question.",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "hint": {
+            "description": "Hint given to help answering the question",
+            "type": "string"
+        }
+    },
+    "required": [
+        "difficulty",
+        "grading",
+        "id",
+        "kind",
+        "question",
+        "spec"
+    ],
+    "definitions": {
+        "Quizoot.MultipleChoicesQuestionSpec": {
+            "type": "object",
+            "properties": {
+                "options": {
+                    "description": "Question options. See {@link QuestionOption}.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Quizoot.QuestionOption"
+                    }
+                },
+                "answers_id": {
+                    "description": "Id of the correct answers to the question.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "answers_id",
+                "options"
+            ]
+        },
+        "Quizoot.QuestionOption": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "description": "Id of the option.",
+                    "type": "string"
+                },
+                "display": {
+                    "description": "The actual display of the option as a human-readable string.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "display",
+                "id"
+            ]
+        },
+        "Quizoot.Grading": {
+            "type": "object",
+            "properties": {
+                "point_value": {
+                    "description": "Specifies how much a correct answer count for in the total score.",
+                    "type": "number"
+                },
+                "feedback": {
+                    "$ref": "#/definitions/Quizoot.Feedback",
+                    "description": "Feedback given after answering the question."
+                }
+            },
+            "required": [
+                "feedback",
+                "point_value"
+            ]
+        },
+        "Quizoot.Feedback": {
+            "type": "object",
+            "properties": {
+                "explanation": {
+                    "description": "General feedback/explanation displayed whether the answer is wrong or correct.",
+                    "type": "string"
+                },
+                "when_wrong": {
+                    "description": "Feedback when answer is wrong.",
+                    "type": "string"
+                },
+                "when_right": {
+                    "description": "Feedback when answer is right.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "explanation"
+            ]
+        },
+        "Quizoot.Difficulty": {
+            "description": "Question difficulty: easy, medium or hard.",
+            "enum": [
+                "EASY",
+                "HARD",
+                "MEDIUM"
+            ],
+            "type": "string"
+        }
+    },
+    "$schema": "http://json-schema.org/draft-07/schema#"
+}

--- a/interfaces/schemas/question.json
+++ b/interfaces/schemas/question.json
@@ -1,297 +1,407 @@
 {
-  "description": "Question object used to create a quiz. A Quiz is a set of questions.",
-  "type": "object",
-  "properties": {
-    "id": {
-      "description": "Id of the question",
-      "pattern": "[a-z0-9]{24}",
-      "type": "string"
-    },
-    "question": {
-      "description": "The actual question as a human-readable string.",
-      "type": "string"
-    },
-    "kind": {
-      "$ref": "#/definitions/Quizoot.QuestionKind",
-      "description": "The question kind. Please refer to {@link QuestionKind}."
-    },
-    "spec": {
-      "$ref": "#/definitions/Quizoot.QuestionSpec",
-      "description": "Spec of the question. It specifies what the attributes of the question are. Attributes depends on {@link QuestionKind}.\n\nSee {@link QuestionSpec} for more information about the spec attributes for each question kind."
-    },
-    "grading": {
-      "$ref": "#/definitions/Quizoot.Grading",
-      "description": "The grading object specifies how to grade for the current question. See {@link Grading}."
-    },
-    "difficulty": {
-      "$ref": "#/definitions/Quizoot.Difficulty",
-      "description": "Rate how difficult the question is. See {@link Difficulty}."
-    },
-    "tags": {
-      "description": "List of optional tags associated with the question.",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "hint": {
-      "description": "Hint given to help answering the question",
-      "type": "string"
-    }
-  },
-  "required": [
-    "difficulty",
-    "grading",
-    "id",
-    "kind",
-    "question",
-    "spec"
-  ],
-  "definitions": {
-    "Quizoot.QuestionKind": {
-      "description": "Different kind of question we might have.",
-      "enum": [
-        "CHOICE_QUESTION",
-        "CODE_QUESTION",
-        "TEXT_QUESTION",
-        "UPLOAD_QUESTION"
-      ],
-      "type": "string"
-    },
-    "Quizoot.QuestionSpec": {
-      "description": "Question spec. It depends on the question kind.",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Quizoot.SingleChoiceQuestion"
-        },
-        {
-          "$ref": "#/definitions/Quizoot.MultipleChoicesQuestion"
-        },
-        {
-          "$ref": "#/definitions/Quizoot.TextQuestion"
-        },
-        {
-          "$ref": "#/definitions/Quizoot.UploadQuestion"
-        },
-        {
-          "$ref": "#/definitions/Quizoot.CodeQuestion"
-        }
-      ]
-    },
-    "Quizoot.SingleChoiceQuestion": {
-      "type": "object",
-      "properties": {
-        "options": {
-          "description": "Question options. See {@link QuestionOption}.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Quizoot.QuestionOption"
-          }
-        },
-        "answer_id": {
-          "description": "Id of the correct answer to the question.",
-          "type": "string"
-        }
-      },
-      "required": [
-        "answer_id",
-        "options"
-      ]
-    },
-    "Quizoot.QuestionOption": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "description": "Id of the option.",
-          "type": "string"
-        },
-        "display": {
-          "description": "The actual display of the option as a human-readable string.",
-          "type": "string"
-        }
-      },
-      "required": [
-        "display",
-        "id"
-      ]
-    },
-    "Quizoot.MultipleChoicesQuestion": {
-      "type": "object",
-      "properties": {
-        "options": {
-          "description": "Question options. See {@link QuestionOption}.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Quizoot.QuestionOption"
-          }
-        },
-        "answers_id": {
-          "description": "Id of the correct answers to the question.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      },
-      "required": [
-        "answers_id",
-        "options"
-      ]
-    },
-    "Quizoot.TextQuestion": {
-      "type": "object",
-      "properties": {
-        "placeholder": {
-          "description": "Placeholder to display in the html `textarea` or `input`",
-          "examples": [
-            "Type your text here..."
-          ],
-          "type": "string"
-        },
-        "keywords": {
-          "description": "List of keywords that the answers should contain. It is up to the developer to implement if the answer should contain ALL or ANY of the keywords.",
-          "examples": [
-            "bytes",
-            "octets"
-          ],
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "Quizoot.UploadQuestion": {
-      "type": "object",
-      "properties": {
-        "files": {
-          "description": "List of files to upload.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Quizoot.File"
-          }
-        },
-        "max_size": {
-          "description": "Maximum size of each files. Can be expressed in bytes, megabytes (MB), etc. See TODO for valid units.",
-          "examples": [
-            "10MB"
-          ],
-          "type": "string"
-        },
-        "max_files": {
-          "description": "Maximum number of files to upload.",
-          "default": 1,
-          "minimum": 1,
-          "type": "number"
-        }
-      },
-      "required": [
-        "files",
-        "max_files",
-        "max_size"
-      ]
-    },
-    "Quizoot.File": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "$ref": "#/definitions/Quizoot.FileType",
-          "description": "File type enum. Can be `.txt`, `.csv`, `.pdf`, etc. See {@link FileType}."
-        },
-        "content": {
-          "description": "Encoded `base64` string of the file's content.",
-          "type": "string"
-        }
-      },
-      "required": [
-        "content",
-        "type"
-      ]
-    },
-    "Quizoot.FileType": {
-      "description": "Enum of supported file extensions.",
-      "enum": [
-        ".csv",
-        ".img",
-        ".jpeg",
-        ".jpg",
-        ".pdf",
-        ".png",
-        ".txt"
-      ],
-      "type": "string"
-    },
-    "Quizoot.CodeQuestion": {
-      "type": "object",
-      "properties": {
-        "content": {
-          "description": "Code content. This will be run using a `python3` runner and evaluated.",
-          "type": "string"
-        },
-        "language": {
-          "description": "Coding language. Only `python3` is supported.",
-          "type": "string",
-          "enum": [
-            "python3"
-          ]
-        },
-        "expected_output": {
-          "description": "Expected output after running the code.",
-          "type": "string"
-        }
-      },
-      "required": [
-        "content",
-        "expected_output",
-        "language"
-      ]
-    },
-    "Quizoot.Grading": {
-      "type": "object",
-      "properties": {
-        "point_value": {
-          "description": "Specifies how much a correct answer count for in the total score.",
-          "type": "number"
-        },
-        "feedback": {
-          "$ref": "#/definitions/Quizoot.Feedback",
-          "description": "Feedback given after answering the question."
-        }
-      },
-      "required": [
-        "feedback",
-        "point_value"
-      ]
-    },
-    "Quizoot.Feedback": {
-      "type": "object",
-      "properties": {
-        "explanation": {
-          "description": "General feedback/explanation displayed whether the answer is wrong or correct.",
-          "type": "string"
-        },
-        "when_wrong": {
-          "description": "Feedback when answer is wrong.",
-          "type": "string"
-        },
-        "when_right": {
-          "description": "Feedback when answer is right.",
-          "type": "string"
-        }
-      },
-      "required": [
-        "explanation"
-      ]
-    },
-    "Quizoot.Difficulty": {
-      "description": "Question difficulty: easy, medium or hard.",
-      "enum": [
-        "EASY",
-        "HARD",
-        "MEDIUM"
-      ],
-      "type": "string"
-    }
-  },
-  "$schema": "http://json-schema.org/draft-07/schema#"
+	"description": "Question object used to create a quiz. A Quiz is a set of questions.",
+	"anyOf": [
+		{
+			"$ref": "#/definitions/Quizoot.SingleChoiceQuestion"
+		},
+		{
+			"$ref": "#/definitions/Quizoot.MultipleChoicesQuestion"
+		},
+		{
+			"$ref": "#/definitions/Quizoot.TextQuestion"
+		},
+		{
+			"$ref": "#/definitions/Quizoot.UploadQuestion"
+		},
+		{
+			"$ref": "#/definitions/Quizoot.CodeQuestion"
+		}
+	],
+	"definitions": {
+		"Quizoot.SingleChoiceQuestion": {
+			"type": "object",
+			"properties": {
+				"id": {
+					"description": "Id of the question",
+					"pattern": "[a-z0-9]{24}",
+					"type": "string"
+				},
+				"question": {
+					"description": "The actual question as a human-readable string.",
+					"type": "string"
+				},
+				"kind": {
+					"description": "The question kind. Please refer to {@link QuestionKind}.",
+					"type": "string",
+					"enum": ["SINGLE_CHOICE_QUESTION"]
+				},
+				"spec": {
+					"$ref": "#/definitions/Quizoot.SingleChoiceQuestionSpec",
+					"description": "Spec of the question. It specifies what the attributes of the question are. Attributes depends on {@link QuestionKind}.\n\nSee {@link QuestionSpec} for more information about the spec attributes for each question kind."
+				},
+				"grading": {
+					"$ref": "#/definitions/Quizoot.Grading",
+					"description": "The grading object specifies how to grade for the current question. See {@link Grading}."
+				},
+				"difficulty": {
+					"$ref": "#/definitions/Quizoot.Difficulty",
+					"description": "Rate how difficult the question is. See {@link Difficulty}."
+				},
+				"tags": {
+					"description": "List of optional tags associated with the question.",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"hint": {
+					"description": "Hint given to help answering the question",
+					"type": "string"
+				}
+			},
+			"required": ["difficulty", "grading", "id", "kind", "question", "spec"]
+		},
+		"Quizoot.SingleChoiceQuestionSpec": {
+			"description": "Question spec. It depends on the question kind.",
+			"type": "object",
+			"properties": {
+				"options": {
+					"description": "Question options. See {@link QuestionOption}.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/Quizoot.QuestionOption"
+					}
+				},
+				"answer_id": {
+					"description": "Id of the correct answer to the question.",
+					"type": "string"
+				}
+			},
+			"required": ["answer_id", "options"]
+		},
+		"Quizoot.QuestionOption": {
+			"type": "object",
+			"properties": {
+				"id": {
+					"description": "Id of the option.",
+					"type": "string"
+				},
+				"display": {
+					"description": "The actual display of the option as a human-readable string.",
+					"type": "string"
+				}
+			},
+			"required": ["display", "id"]
+		},
+		"Quizoot.Grading": {
+			"type": "object",
+			"properties": {
+				"point_value": {
+					"description": "Specifies how much a correct answer count for in the total score.",
+					"type": "number"
+				},
+				"feedback": {
+					"$ref": "#/definitions/Quizoot.Feedback",
+					"description": "Feedback given after answering the question."
+				}
+			},
+			"required": ["feedback", "point_value"]
+		},
+		"Quizoot.Feedback": {
+			"type": "object",
+			"properties": {
+				"explanation": {
+					"description": "General feedback/explanation displayed whether the answer is wrong or correct.",
+					"type": "string"
+				},
+				"when_wrong": {
+					"description": "Feedback when answer is wrong.",
+					"type": "string"
+				},
+				"when_right": {
+					"description": "Feedback when answer is right.",
+					"type": "string"
+				}
+			},
+			"required": ["explanation"]
+		},
+		"Quizoot.Difficulty": {
+			"description": "Question difficulty: easy, medium or hard.",
+			"enum": ["EASY", "HARD", "MEDIUM"],
+			"type": "string"
+		},
+		"Quizoot.MultipleChoicesQuestion": {
+			"type": "object",
+			"properties": {
+				"id": {
+					"description": "Id of the question",
+					"pattern": "[a-z0-9]{24}",
+					"type": "string"
+				},
+				"question": {
+					"description": "The actual question as a human-readable string.",
+					"type": "string"
+				},
+				"kind": {
+					"description": "The question kind. Please refer to {@link QuestionKind}.",
+					"type": "string",
+					"enum": ["MULTIPLE_CHOICES_QUESTION"]
+				},
+				"spec": {
+					"$ref": "#/definitions/Quizoot.MultipleChoicesQuestionSpec",
+					"description": "Spec of the question. It specifies what the attributes of the question are. Attributes depends on {@link QuestionKind}.\n\nSee {@link QuestionSpec} for more information about the spec attributes for each question kind."
+				},
+				"grading": {
+					"$ref": "#/definitions/Quizoot.Grading",
+					"description": "The grading object specifies how to grade for the current question. See {@link Grading}."
+				},
+				"difficulty": {
+					"$ref": "#/definitions/Quizoot.Difficulty",
+					"description": "Rate how difficult the question is. See {@link Difficulty}."
+				},
+				"tags": {
+					"description": "List of optional tags associated with the question.",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"hint": {
+					"description": "Hint given to help answering the question",
+					"type": "string"
+				}
+			},
+			"required": ["difficulty", "grading", "id", "kind", "question", "spec"]
+		},
+		"Quizoot.MultipleChoicesQuestionSpec": {
+			"type": "object",
+			"properties": {
+				"options": {
+					"description": "Question options. See {@link QuestionOption}.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/Quizoot.QuestionOption"
+					}
+				},
+				"answers_id": {
+					"description": "Id of the correct answers to the question.",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				}
+			},
+			"required": ["answers_id", "options"]
+		},
+		"Quizoot.TextQuestion": {
+			"type": "object",
+			"properties": {
+				"id": {
+					"description": "Id of the question",
+					"pattern": "[a-z0-9]{24}",
+					"type": "string"
+				},
+				"question": {
+					"description": "The actual question as a human-readable string.",
+					"type": "string"
+				},
+				"kind": {
+					"description": "The question kind. Please refer to {@link QuestionKind}.",
+					"type": "string",
+					"enum": ["TEXT_QUESTION"]
+				},
+				"spec": {
+					"$ref": "#/definitions/Quizoot.TextQuestionSpec",
+					"description": "Spec of the question. It specifies what the attributes of the question are. Attributes depends on {@link QuestionKind}.\n\nSee {@link QuestionSpec} for more information about the spec attributes for each question kind."
+				},
+				"grading": {
+					"$ref": "#/definitions/Quizoot.Grading",
+					"description": "The grading object specifies how to grade for the current question. See {@link Grading}."
+				},
+				"difficulty": {
+					"$ref": "#/definitions/Quizoot.Difficulty",
+					"description": "Rate how difficult the question is. See {@link Difficulty}."
+				},
+				"tags": {
+					"description": "List of optional tags associated with the question.",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"hint": {
+					"description": "Hint given to help answering the question",
+					"type": "string"
+				}
+			},
+			"required": ["difficulty", "grading", "id", "kind", "question", "spec"]
+		},
+		"Quizoot.TextQuestionSpec": {
+			"type": "object",
+			"properties": {
+				"placeholder": {
+					"description": "Placeholder to display in the html `textarea` or `input`",
+					"examples": ["Type your text here..."],
+					"type": "string"
+				},
+				"keywords": {
+					"description": "List of keywords that the answers should contain. It is up to the developer to implement if the answer should contain ALL or ANY of the keywords.",
+					"examples": ["bytes", "octets"],
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				}
+			}
+		},
+		"Quizoot.UploadQuestion": {
+			"type": "object",
+			"properties": {
+				"id": {
+					"description": "Id of the question",
+					"pattern": "[a-z0-9]{24}",
+					"type": "string"
+				},
+				"question": {
+					"description": "The actual question as a human-readable string.",
+					"type": "string"
+				},
+				"kind": {
+					"description": "The question kind. Please refer to {@link QuestionKind}.",
+					"type": "string",
+					"enum": ["UPLOAD_QUESTION"]
+				},
+				"spec": {
+					"$ref": "#/definitions/Quizoot.UploadQuestionSpec",
+					"description": "Spec of the question. It specifies what the attributes of the question are. Attributes depends on {@link QuestionKind}.\n\nSee {@link QuestionSpec} for more information about the spec attributes for each question kind."
+				},
+				"grading": {
+					"$ref": "#/definitions/Quizoot.Grading",
+					"description": "The grading object specifies how to grade for the current question. See {@link Grading}."
+				},
+				"difficulty": {
+					"$ref": "#/definitions/Quizoot.Difficulty",
+					"description": "Rate how difficult the question is. See {@link Difficulty}."
+				},
+				"tags": {
+					"description": "List of optional tags associated with the question.",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"hint": {
+					"description": "Hint given to help answering the question",
+					"type": "string"
+				}
+			},
+			"required": ["difficulty", "grading", "id", "kind", "question", "spec"]
+		},
+		"Quizoot.UploadQuestionSpec": {
+			"type": "object",
+			"properties": {
+				"files": {
+					"description": "List of files to upload.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/Quizoot.File"
+					}
+				},
+				"max_size": {
+					"description": "Maximum size of each files. Can be expressed in bytes, megabytes (MB), etc. See TODO for valid units.",
+					"examples": ["10MB"],
+					"type": "string"
+				},
+				"max_files": {
+					"description": "Maximum number of files to upload.",
+					"default": 1,
+					"minimum": 1,
+					"type": "number"
+				}
+			},
+			"required": ["files", "max_files", "max_size"]
+		},
+		"Quizoot.File": {
+			"type": "object",
+			"properties": {
+				"type": {
+					"$ref": "#/definitions/Quizoot.FileType",
+					"description": "File type enum. Can be `.txt`, `.csv`, `.pdf`, etc. See {@link FileType}."
+				},
+				"content": {
+					"description": "Encoded `base64` string of the file's content.",
+					"type": "string"
+				}
+			},
+			"required": ["content", "type"]
+		},
+		"Quizoot.FileType": {
+			"description": "Enum of supported file extensions.",
+			"enum": [".csv", ".img", ".jpeg", ".jpg", ".pdf", ".png", ".txt"],
+			"type": "string"
+		},
+		"Quizoot.CodeQuestion": {
+			"type": "object",
+			"properties": {
+				"id": {
+					"description": "Id of the question",
+					"pattern": "[a-z0-9]{24}",
+					"type": "string"
+				},
+				"question": {
+					"description": "The actual question as a human-readable string.",
+					"type": "string"
+				},
+				"kind": {
+					"description": "The question kind. Please refer to {@link QuestionKind}.",
+					"type": "string",
+					"enum": ["CODE_QUESTION"]
+				},
+				"spec": {
+					"$ref": "#/definitions/Quizoot.CodeQuestionSpec",
+					"description": "Spec of the question. It specifies what the attributes of the question are. Attributes depends on {@link QuestionKind}.\n\nSee {@link QuestionSpec} for more information about the spec attributes for each question kind."
+				},
+				"grading": {
+					"$ref": "#/definitions/Quizoot.Grading",
+					"description": "The grading object specifies how to grade for the current question. See {@link Grading}."
+				},
+				"difficulty": {
+					"$ref": "#/definitions/Quizoot.Difficulty",
+					"description": "Rate how difficult the question is. See {@link Difficulty}."
+				},
+				"tags": {
+					"description": "List of optional tags associated with the question.",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"hint": {
+					"description": "Hint given to help answering the question",
+					"type": "string"
+				}
+			},
+			"required": ["difficulty", "grading", "id", "kind", "question", "spec"]
+		},
+		"Quizoot.CodeQuestionSpec": {
+			"type": "object",
+			"properties": {
+				"content": {
+					"description": "Code content. This will be run using a `python3` runner and evaluated.",
+					"type": "string"
+				},
+				"language": {
+					"description": "Coding language. Only `python3` is supported.",
+					"type": "string",
+					"enum": ["python3"]
+				},
+				"expected_output": {
+					"description": "Expected output after running the code.",
+					"type": "string"
+				}
+			},
+			"required": ["content", "expected_output", "language"]
+		}
+	},
+	"$schema": "http://json-schema.org/draft-07/schema#"
 }

--- a/interfaces/schemas/question_kind.json
+++ b/interfaces/schemas/question_kind.json
@@ -1,0 +1,12 @@
+{
+    "description": "Different kind of question we might have.",
+    "enum": [
+        "CODE_QUESTION",
+        "MULTIPLE_CHOICES_QUESTION",
+        "SINGLE_CHOICE_QUESTION",
+        "TEXT_QUESTION",
+        "UPLOAD_QUESTION"
+    ],
+    "type": "string",
+    "$schema": "http://json-schema.org/draft-07/schema#"
+}

--- a/interfaces/schemas/quiz.json
+++ b/interfaces/schemas/quiz.json
@@ -1,112 +1,112 @@
 {
-  "description": "A Quiz object represents a set of questions.",
-  "type": "object",
-  "properties": {
-    "id": {
-      "description": "Id of the quiz.",
-      "pattern": "[a-z0-9]{24}",
-      "type": "string"
-    },
-    "title": {
-      "description": "The title (header) of the quiz.",
-      "minLength": 1,
-      "maxLength": 40,
-      "type": "string"
-    },
-    "description": {
-      "description": "A brief description of the quiz content, topic...",
-      "type": "string"
-    },
-    "max_score": {
-      "description": "Maximum score the user can get. Will be used to compute the final score: sum(question_i_score) / max_score.",
-      "default": 0,
-      "minimum": 0,
-      "type": "number"
-    },
-    "questions": {
-      "description": "All the questions the quiz is made of.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/Quizoot.QuestionItem"
-      }
-    },
-    "authors": {
-      "description": "List of optional authors or contributors of the quiz. See {@link Author}.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/Quizoot.Author"
-      }
-    },
-    "tags": {
-      "description": "List of optional tags associated with the quiz.",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    }
-  },
-  "required": [
-    "description",
-    "id",
-    "max_score",
-    "questions",
-    "title"
-  ],
-  "definitions": {
-    "Quizoot.QuestionItem": {
-      "type": "object",
-      "properties": {
-        "question_id": {
-          "description": "Id of a question referenced in the quiz.",
-          "pattern": "[a-z0-9]{24}",
-          "type": "string"
+    "description": "A Quiz object represents a set of questions.",
+    "type": "object",
+    "properties": {
+        "id": {
+            "description": "Id of the quiz.",
+            "pattern": "[a-z0-9]{24}",
+            "type": "string"
         },
-        "next_question_id": {
-          "description": "Id of the next question in the quiz chronology. Is null if it is the last question.",
-          "type": [
-            "string",
-            "null"
-          ]
+        "title": {
+            "description": "The title (header) of the quiz.",
+            "minLength": 1,
+            "maxLength": 40,
+            "type": "string"
         },
-        "prev_question_id": {
-          "description": "Id of the previous question in the quiz chronology. Is null if it is the first question.",
-          "type": [
-            "string",
-            "null"
-          ]
+        "description": {
+            "description": "A brief description of the quiz content, topic...",
+            "type": "string"
+        },
+        "max_score": {
+            "description": "Maximum score the user can get. Will be used to compute the final score: sum(question_i_score) / max_score.",
+            "default": 0,
+            "minimum": 0,
+            "type": "number"
+        },
+        "questions": {
+            "description": "All the questions the quiz is made of.",
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/Quizoot.QuestionItem"
+            }
+        },
+        "authors": {
+            "description": "List of optional authors or contributors of the quiz. See {@link Author}.",
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/Quizoot.Author"
+            }
+        },
+        "tags": {
+            "description": "List of optional tags associated with the quiz.",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
         }
-      },
-      "required": [
-        "next_question_id",
-        "prev_question_id",
-        "question_id"
-      ]
     },
-    "Quizoot.Author": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "description": "The quiz author's first name.",
-          "type": "string"
+    "required": [
+        "description",
+        "id",
+        "max_score",
+        "questions",
+        "title"
+    ],
+    "definitions": {
+        "Quizoot.QuestionItem": {
+            "type": "object",
+            "properties": {
+                "question_id": {
+                    "description": "Id of a question referenced in the quiz.",
+                    "pattern": "[a-z0-9]{24}",
+                    "type": "string"
+                },
+                "next_question_id": {
+                    "description": "Id of the next question in the quiz chronology. Is null if it is the last question.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "prev_question_id": {
+                    "description": "Id of the previous question in the quiz chronology. Is null if it is the first question.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "required": [
+                "next_question_id",
+                "prev_question_id",
+                "question_id"
+            ]
         },
-        "surname": {
-          "description": "The quiz author's last name. Is optional.",
-          "type": "string"
-        },
-        "pseudo": {
-          "description": "A pseudo for the quiz author.",
-          "type": "string"
-        },
-        "email": {
-          "description": "The quiz author's email.",
-          "pattern": "^[a-zA-Z]+[\\w.\\d-]*@[a-zA-Z]+\\.[a-zA-Z]{1,3}$",
-          "type": "string"
+        "Quizoot.Author": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "description": "The quiz author's first name.",
+                    "type": "string"
+                },
+                "surname": {
+                    "description": "The quiz author's last name. Is optional.",
+                    "type": "string"
+                },
+                "pseudo": {
+                    "description": "A pseudo for the quiz author.",
+                    "type": "string"
+                },
+                "email": {
+                    "description": "The quiz author's email.",
+                    "pattern": "^[a-zA-Z]+[\\w.\\d-]*@[a-zA-Z]+\\.[a-zA-Z]{1,3}$",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
-      },
-      "required": [
-        "name"
-      ]
-    }
-  },
-  "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "$schema": "http://json-schema.org/draft-07/schema#"
 }

--- a/interfaces/schemas/single_choice_question.json
+++ b/interfaces/schemas/single_choice_question.json
@@ -1,0 +1,139 @@
+{
+    "type": "object",
+    "properties": {
+        "id": {
+            "description": "Id of the question",
+            "pattern": "[a-z0-9]{24}",
+            "type": "string"
+        },
+        "question": {
+            "description": "The actual question as a human-readable string.",
+            "type": "string"
+        },
+        "kind": {
+            "description": "The question kind. Please refer to {@link QuestionKind}.",
+            "type": "string",
+            "enum": [
+                "SINGLE_CHOICE_QUESTION"
+            ]
+        },
+        "spec": {
+            "$ref": "#/definitions/Quizoot.SingleChoiceQuestionSpec",
+            "description": "Spec of the question. It specifies what the attributes of the question are. Attributes depends on {@link QuestionKind}.\n\nSee {@link QuestionSpec} for more information about the spec attributes for each question kind."
+        },
+        "grading": {
+            "$ref": "#/definitions/Quizoot.Grading",
+            "description": "The grading object specifies how to grade for the current question. See {@link Grading}."
+        },
+        "difficulty": {
+            "$ref": "#/definitions/Quizoot.Difficulty",
+            "description": "Rate how difficult the question is. See {@link Difficulty}."
+        },
+        "tags": {
+            "description": "List of optional tags associated with the question.",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "hint": {
+            "description": "Hint given to help answering the question",
+            "type": "string"
+        }
+    },
+    "required": [
+        "difficulty",
+        "grading",
+        "id",
+        "kind",
+        "question",
+        "spec"
+    ],
+    "definitions": {
+        "Quizoot.SingleChoiceQuestionSpec": {
+            "description": "Question spec. It depends on the question kind.",
+            "type": "object",
+            "properties": {
+                "options": {
+                    "description": "Question options. See {@link QuestionOption}.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Quizoot.QuestionOption"
+                    }
+                },
+                "answer_id": {
+                    "description": "Id of the correct answer to the question.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "answer_id",
+                "options"
+            ]
+        },
+        "Quizoot.QuestionOption": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "description": "Id of the option.",
+                    "type": "string"
+                },
+                "display": {
+                    "description": "The actual display of the option as a human-readable string.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "display",
+                "id"
+            ]
+        },
+        "Quizoot.Grading": {
+            "type": "object",
+            "properties": {
+                "point_value": {
+                    "description": "Specifies how much a correct answer count for in the total score.",
+                    "type": "number"
+                },
+                "feedback": {
+                    "$ref": "#/definitions/Quizoot.Feedback",
+                    "description": "Feedback given after answering the question."
+                }
+            },
+            "required": [
+                "feedback",
+                "point_value"
+            ]
+        },
+        "Quizoot.Feedback": {
+            "type": "object",
+            "properties": {
+                "explanation": {
+                    "description": "General feedback/explanation displayed whether the answer is wrong or correct.",
+                    "type": "string"
+                },
+                "when_wrong": {
+                    "description": "Feedback when answer is wrong.",
+                    "type": "string"
+                },
+                "when_right": {
+                    "description": "Feedback when answer is right.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "explanation"
+            ]
+        },
+        "Quizoot.Difficulty": {
+            "description": "Question difficulty: easy, medium or hard.",
+            "enum": [
+                "EASY",
+                "HARD",
+                "MEDIUM"
+            ],
+            "type": "string"
+        }
+    },
+    "$schema": "http://json-schema.org/draft-07/schema#"
+}

--- a/interfaces/schemas/text_question.json
+++ b/interfaces/schemas/text_question.json
@@ -1,0 +1,124 @@
+{
+    "type": "object",
+    "properties": {
+        "id": {
+            "description": "Id of the question",
+            "pattern": "[a-z0-9]{24}",
+            "type": "string"
+        },
+        "question": {
+            "description": "The actual question as a human-readable string.",
+            "type": "string"
+        },
+        "kind": {
+            "description": "The question kind. Please refer to {@link QuestionKind}.",
+            "type": "string",
+            "enum": [
+                "TEXT_QUESTION"
+            ]
+        },
+        "spec": {
+            "$ref": "#/definitions/Quizoot.TextQuestionSpec",
+            "description": "Spec of the question. It specifies what the attributes of the question are. Attributes depends on {@link QuestionKind}.\n\nSee {@link QuestionSpec} for more information about the spec attributes for each question kind."
+        },
+        "grading": {
+            "$ref": "#/definitions/Quizoot.Grading",
+            "description": "The grading object specifies how to grade for the current question. See {@link Grading}."
+        },
+        "difficulty": {
+            "$ref": "#/definitions/Quizoot.Difficulty",
+            "description": "Rate how difficult the question is. See {@link Difficulty}."
+        },
+        "tags": {
+            "description": "List of optional tags associated with the question.",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "hint": {
+            "description": "Hint given to help answering the question",
+            "type": "string"
+        }
+    },
+    "required": [
+        "difficulty",
+        "grading",
+        "id",
+        "kind",
+        "question",
+        "spec"
+    ],
+    "definitions": {
+        "Quizoot.TextQuestionSpec": {
+            "type": "object",
+            "properties": {
+                "placeholder": {
+                    "description": "Placeholder to display in the html `textarea` or `input`",
+                    "examples": [
+                        "Type your text here..."
+                    ],
+                    "type": "string"
+                },
+                "keywords": {
+                    "description": "List of keywords that the answers should contain. It is up to the developer to implement if the answer should contain ALL or ANY of the keywords.",
+                    "examples": [
+                        "bytes",
+                        "octets"
+                    ],
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "Quizoot.Grading": {
+            "type": "object",
+            "properties": {
+                "point_value": {
+                    "description": "Specifies how much a correct answer count for in the total score.",
+                    "type": "number"
+                },
+                "feedback": {
+                    "$ref": "#/definitions/Quizoot.Feedback",
+                    "description": "Feedback given after answering the question."
+                }
+            },
+            "required": [
+                "feedback",
+                "point_value"
+            ]
+        },
+        "Quizoot.Feedback": {
+            "type": "object",
+            "properties": {
+                "explanation": {
+                    "description": "General feedback/explanation displayed whether the answer is wrong or correct.",
+                    "type": "string"
+                },
+                "when_wrong": {
+                    "description": "Feedback when answer is wrong.",
+                    "type": "string"
+                },
+                "when_right": {
+                    "description": "Feedback when answer is right.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "explanation"
+            ]
+        },
+        "Quizoot.Difficulty": {
+            "description": "Question difficulty: easy, medium or hard.",
+            "enum": [
+                "EASY",
+                "HARD",
+                "MEDIUM"
+            ],
+            "type": "string"
+        }
+    },
+    "$schema": "http://json-schema.org/draft-07/schema#"
+}

--- a/interfaces/schemas/upload_question.json
+++ b/interfaces/schemas/upload_question.json
@@ -1,0 +1,161 @@
+{
+    "type": "object",
+    "properties": {
+        "id": {
+            "description": "Id of the question",
+            "pattern": "[a-z0-9]{24}",
+            "type": "string"
+        },
+        "question": {
+            "description": "The actual question as a human-readable string.",
+            "type": "string"
+        },
+        "kind": {
+            "description": "The question kind. Please refer to {@link QuestionKind}.",
+            "type": "string",
+            "enum": [
+                "UPLOAD_QUESTION"
+            ]
+        },
+        "spec": {
+            "$ref": "#/definitions/Quizoot.UploadQuestionSpec",
+            "description": "Spec of the question. It specifies what the attributes of the question are. Attributes depends on {@link QuestionKind}.\n\nSee {@link QuestionSpec} for more information about the spec attributes for each question kind."
+        },
+        "grading": {
+            "$ref": "#/definitions/Quizoot.Grading",
+            "description": "The grading object specifies how to grade for the current question. See {@link Grading}."
+        },
+        "difficulty": {
+            "$ref": "#/definitions/Quizoot.Difficulty",
+            "description": "Rate how difficult the question is. See {@link Difficulty}."
+        },
+        "tags": {
+            "description": "List of optional tags associated with the question.",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "hint": {
+            "description": "Hint given to help answering the question",
+            "type": "string"
+        }
+    },
+    "required": [
+        "difficulty",
+        "grading",
+        "id",
+        "kind",
+        "question",
+        "spec"
+    ],
+    "definitions": {
+        "Quizoot.UploadQuestionSpec": {
+            "type": "object",
+            "properties": {
+                "files": {
+                    "description": "List of files to upload.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Quizoot.File"
+                    }
+                },
+                "max_size": {
+                    "description": "Maximum size of each files. Can be expressed in bytes, megabytes (MB), etc. See TODO for valid units.",
+                    "examples": [
+                        "10MB"
+                    ],
+                    "type": "string"
+                },
+                "max_files": {
+                    "description": "Maximum number of files to upload.",
+                    "default": 1,
+                    "minimum": 1,
+                    "type": "number"
+                }
+            },
+            "required": [
+                "files",
+                "max_files",
+                "max_size"
+            ]
+        },
+        "Quizoot.File": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "$ref": "#/definitions/Quizoot.FileType",
+                    "description": "File type enum. Can be `.txt`, `.csv`, `.pdf`, etc. See {@link FileType}."
+                },
+                "content": {
+                    "description": "Encoded `base64` string of the file's content.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "content",
+                "type"
+            ]
+        },
+        "Quizoot.FileType": {
+            "description": "Enum of supported file extensions.",
+            "enum": [
+                ".csv",
+                ".img",
+                ".jpeg",
+                ".jpg",
+                ".pdf",
+                ".png",
+                ".txt"
+            ],
+            "type": "string"
+        },
+        "Quizoot.Grading": {
+            "type": "object",
+            "properties": {
+                "point_value": {
+                    "description": "Specifies how much a correct answer count for in the total score.",
+                    "type": "number"
+                },
+                "feedback": {
+                    "$ref": "#/definitions/Quizoot.Feedback",
+                    "description": "Feedback given after answering the question."
+                }
+            },
+            "required": [
+                "feedback",
+                "point_value"
+            ]
+        },
+        "Quizoot.Feedback": {
+            "type": "object",
+            "properties": {
+                "explanation": {
+                    "description": "General feedback/explanation displayed whether the answer is wrong or correct.",
+                    "type": "string"
+                },
+                "when_wrong": {
+                    "description": "Feedback when answer is wrong.",
+                    "type": "string"
+                },
+                "when_right": {
+                    "description": "Feedback when answer is right.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "explanation"
+            ]
+        },
+        "Quizoot.Difficulty": {
+            "description": "Question difficulty: easy, medium or hard.",
+            "enum": [
+                "EASY",
+                "HARD",
+                "MEDIUM"
+            ],
+            "type": "string"
+        }
+    },
+    "$schema": "http://json-schema.org/draft-07/schema#"
+}

--- a/interfaces/yarn.lock
+++ b/interfaces/yarn.lock
@@ -293,6 +293,11 @@ path-is-absolute@^1.0.0:
   resolved "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
   integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
 
+prettier@^2.8.4:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.4.tgz#34dd2595629bfbb79d344ac4a91ff948694463c3"
+  integrity sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==
+
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"


### PR DESCRIPTION
## What does this PR do ?

Refactor a bit the interfaces:
- better typing
- generate schema for each question kind
- this will be used during validation in both frontend and backend

## Why ?
- We need a UI to insert data. I was planning using something like `react-jsonschema-form` (used under the hood by `django-jsonschema-form`). The problem with that approach is that I cannot really write the appropriate django model. Also since the question type is complex, it does not work properly. So we should build our own UI, using something like `vue-json-form` or anything called like that. [This for example](https://roma219.github.io/vue-jsonschema-form/).
- We need to do better validation by specifying which spec goes with a given question kind.

Open to any way to address these issues...
